### PR TITLE
🏄‍♀️ Support consuming Long values

### DIFF
--- a/src/kafka/schema-registry/avro-types/long.ts
+++ b/src/kafka/schema-registry/avro-types/long.ts
@@ -1,0 +1,19 @@
+import avro from 'avsc';
+
+/**
+ * https://github.com/mtth/avsc/wiki/Advanced-usage#custom-long-types
+ */
+export const longType = avro.types.LongType.__with({
+  compare: (n1: bigint, n2: bigint) => {
+    return n1 === n2 ? 0 : (n1 < n2 ? -1 : 1);
+  },
+  fromBuffer: (buf: Buffer) => buf.readBigInt64LE(),
+  fromJSON: BigInt,
+  isValid: (n: unknown): n is bigint => typeof n == 'bigint',
+  toBuffer: (n: bigint) => {
+    const buf = Buffer.alloc(8);
+    buf.writeBigInt64LE(n);
+    return buf;
+  },
+  toJSON: Number,
+});

--- a/src/kafka/schema-registry/index.ts
+++ b/src/kafka/schema-registry/index.ts
@@ -7,6 +7,8 @@ import { ClientError } from '../../errors';
 import log from '../../log';
 import { Convertable, EncodeSchemaOptions, RegistryOptions } from '../../types';
 
+import { longType } from './avro-types/long';
+
 let schemaRegistry: SchemaRegistry;
 let activeSchemaId: number;
 let latestUrl: string;
@@ -53,7 +55,10 @@ export const initSchemaRegistry = async ({ url, auth, encode }: RegistryOptions)
     message = `Initializing schema registry at ${url}`;
     schemaRegistry = new SchemaRegistry(
       { auth, host: url },
-      { [SchemaType.AVRO]: { logicalTypes: { decimal: AvroDecimal } } },
+      { [SchemaType.AVRO]: {
+        logicalTypes: { decimal: AvroDecimal },
+        registry: { 'long': longType },
+      } },
     );
     log.info(message);
     latestUrl = url;


### PR DESCRIPTION
Solves this - https://github.com/loadmill/loadmill-kafka-relay/issues/14

Note: This solves the issue for `consume` (as described in the above issue). This however does not solve the issue for `produce`. If the need (for supporting `produce`) arrises in the future, we will address it.