### PR TITLE
👩‍🔧 LZ4 workaround for node 18 env

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:watch": "nodemon --inspect=0.0.0.0:9221 src/index.ts",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --color",
     "postinstall": "patch-package",
-    "start": "node dist",
+    "start": "node --no-experimental-fetch dist",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
We use [kafkajs-lz4](https://www.npmjs.com/package/kafkajs-lz4) npm package and it has an issue on node 18.
This solution is their suggested workaround.

https://github.com/ukyo/lz4.js/issues/14#issue-1434765066