### PR TITLE
🛞 Avoid message duplication in redis topic

### DIFF
--- a/src/kafka/subscribers/redis-keys.ts
+++ b/src/kafka/subscribers/redis-keys.ts
@@ -17,3 +17,6 @@ export const toTopicMessagesKey = (topic: string): string =>
 
 export const toTopicLeaderKey = (topic: string): string =>
   `${kafkaRelayPrefixKey}:topics:${encodeKeyPart(topic)}:leader`;
+
+export const toTopicPartitionOffsetWatermarksKey = (topic: string): string =>
+  `${kafkaRelayPrefixKey}:topics:${encodeKeyPart(topic)}:partition-offset-watermarks`;

--- a/src/kafka/subscribers/redis-subscriber.ts
+++ b/src/kafka/subscribers/redis-subscriber.ts
@@ -79,6 +79,18 @@ export class RedisSubscriber extends Subscriber {
     }
   }
 
+  // Re-seeks a running topic consumer to a past timestamp and resets the
+  // deduplication watermark so replayed messages are not silently dropped.
+  async reseekToTimestamp(timestamp: number): Promise<void> {
+    if (!this.consumer || !this.kafka) {
+      throw new Error('Kafka consumer is not initialized');
+    }
+    const watermarkKey = toTopicPartitionOffsetWatermarksKey(this.topic);
+    await this.redisClient.del(watermarkKey);
+    const partitions = await getPartitionsByTimestamp(this.kafka, this.topic, timestamp);
+    await seekToPartitions(this.consumer, partitions, this.topic);
+  }
+
   // Used when this subscriber acts as the shared topic consumer (asTopicConsumer = true).
   // Only seeks by timestamp when explicitly provided — crash recovery relies on committed offsets.
   async subscribeAsTopicConsumer(timestamp?: number): Promise<void> {

--- a/src/kafka/subscribers/redis-subscriber.ts
+++ b/src/kafka/subscribers/redis-subscriber.ts
@@ -5,6 +5,7 @@ import {
   PartitionOffset,
 } from '@confluentinc/kafka-javascript/types/kafkajs';
 
+import log from '../../log';
 import { thisRelayInstanceId } from '../../multi-instance';
 import { getRedisClient } from '../../redis/redis-client';
 import { RedisClient } from '../../redis/types';
@@ -17,7 +18,11 @@ import {
   getMessagesFromRedis,
   normalizeConsumedMessageValue,
 } from './messages';
-import { toTopicMessagesKey } from './redis-keys';
+import {
+  toTopicMessagesKey,
+  toTopicPartitionOffsetWatermarksKey,
+} from './redis-keys';
+import { appendTopicMessageWithDedupe } from './redis-topic-dedupe';
 import { ShallowSubscriber, Subscriber } from './subscriber';
 import { ensureTopicConsumerRunning } from './topic-consumers-manager';
 import { toTopicGroupId } from './topic-utils';
@@ -44,7 +49,7 @@ export class RedisSubscriber extends Subscriber {
     debugParams && (this.instanceId = debugParams.instanceId);
   }
 
-  async addMessage({ message }: EachMessagePayload): Promise<void> {
+  async addMessage({ message, partition }: EachMessagePayload): Promise<void> {
     const consumedMessage = await fromKafkaToConsumedMessage(message);
 
     // Normalize the value to ensure Avro union types are type mapped
@@ -52,17 +57,26 @@ export class RedisSubscriber extends Subscriber {
 
     const messageToStore = {
       ...consumedMessage,
+      partition,
       value: normalizedValue,
     };
 
     const serializedMessage = JSON.stringify(messageToStore);
     const messagesKey = toTopicMessagesKey(this.topic);
-
-    await this.redisClient.multi()
-      .rPush(messagesKey, serializedMessage)
-      .lTrim(messagesKey, -MAX_TOPIC_MESSAGES_LENGTH, -1)
-      .expire(messagesKey, TOPIC_MESSAGES_TTL_SECONDS)
-      .exec();
+    const watermarkKey = toTopicPartitionOffsetWatermarksKey(this.topic);
+    const result = await appendTopicMessageWithDedupe({
+      maxMessages: MAX_TOPIC_MESSAGES_LENGTH,
+      messagesKey,
+      offset: message.offset,
+      partition,
+      redisClient: this.redisClient,
+      serializedMessage,
+      ttlSeconds: TOPIC_MESSAGES_TTL_SECONDS,
+      watermarkKey,
+    });
+    if (result === 'duplicate') {
+      log.debug({ offset: message.offset, partition, topic: this.topic }, 'Skipped duplicate topic message');
+    }
   }
 
   // Used when this subscriber acts as the shared topic consumer (asTopicConsumer = true).

--- a/src/kafka/subscribers/redis-subscriber.ts
+++ b/src/kafka/subscribers/redis-subscriber.ts
@@ -92,7 +92,7 @@ export class RedisSubscriber extends Subscriber {
   }
 
   // Used when this subscriber acts as the shared topic consumer (asTopicConsumer = true).
-  // Only seeks by timestamp when explicitly provided — crash recovery relies on committed offsets.
+  // If no timestamp is provided, default to 1 minute ago (same behavior as base Subscriber).
   async subscribeAsTopicConsumer(timestamp?: number): Promise<void> {
     if (!this.consumer || !this.kafka) {
       throw new Error('Kafka consumer is not initialized');
@@ -106,11 +106,8 @@ export class RedisSubscriber extends Subscriber {
       },
     });
 
-    if (timestamp == null) {
-      return;
-    }
-
-    const partitions = await getPartitionsByTimestamp(this.kafka, this.topic, timestamp);
+    const effectiveTimestamp = timestamp ?? get1MinuteAgoTimestamp();
+    const partitions = await getPartitionsByTimestamp(this.kafka, this.topic, effectiveTimestamp);
     await seekToPartitions(this.consumer, partitions, this.topic);
   }
 
@@ -167,3 +164,5 @@ const seekToPartitions = async (consumer: Consumer, partitions: PartitionOffset[
     ),
   );
 };
+
+const get1MinuteAgoTimestamp = () => Date.now() - 60 * 1000;

--- a/src/kafka/subscribers/redis-subscriber.ts
+++ b/src/kafka/subscribers/redis-subscriber.ts
@@ -106,7 +106,7 @@ export class RedisSubscriber extends Subscriber {
       },
     });
 
-    const effectiveTimestamp = timestamp ?? get1MinuteAgoTimestamp();
+    const effectiveTimestamp = timestamp ?? this.get1MinuteAgoTimestamp();
     const partitions = await getPartitionsByTimestamp(this.kafka, this.topic, effectiveTimestamp);
     await seekToPartitions(this.consumer, partitions, this.topic);
   }
@@ -164,5 +164,3 @@ const seekToPartitions = async (consumer: Consumer, partitions: PartitionOffset[
     ),
   );
 };
-
-const get1MinuteAgoTimestamp = () => Date.now() - 60 * 1000;

--- a/src/kafka/subscribers/redis-topic-dedupe.ts
+++ b/src/kafka/subscribers/redis-topic-dedupe.ts
@@ -1,0 +1,105 @@
+import { RedisClient } from '../../redis/types';
+
+type AppendResult = 'inserted' | 'duplicate';
+type AppendAttemptResult = AppendResult | 'conflict';
+
+type AppendTopicMessageParams = {
+  maxMessages: number;
+  messagesKey: string;
+  offset: string;
+  partition: number;
+  redisClient: RedisClient;
+  serializedMessage: string;
+  ttlSeconds: number;
+  watermarkKey: string;
+};
+
+const WATCH_CONFLICT_MAX_RETRIES = 8;
+const WATCH_CONFLICT_BACKOFF_MIN_MS = 5;
+const WATCH_CONFLICT_BACKOFF_MAX_MS = 30;
+
+export const appendTopicMessageWithDedupe = async (
+  params: AppendTopicMessageParams,
+): Promise<AppendResult> => {
+  for (let attempt = 1; attempt <= WATCH_CONFLICT_MAX_RETRIES; attempt += 1) {
+    const result = await attemptAtomicAppendWithWatch(params);
+    if (result !== 'conflict') {
+      return result;
+    }
+    await sleep(getWatchConflictBackoffMs());
+  }
+
+  throw new Error(`Failed to append deduped topic message after ${WATCH_CONFLICT_MAX_RETRIES} WATCH conflicts`);
+};
+
+const attemptAtomicAppendWithWatch = async (
+  {
+    maxMessages,
+    messagesKey,
+    offset,
+    partition,
+    redisClient,
+    serializedMessage,
+    ttlSeconds,
+    watermarkKey,
+  }: AppendTopicMessageParams,
+): Promise<AppendAttemptResult> => {
+  return await redisClient.executeIsolated(async (isolatedRedisClient) => {
+    const partitionField = partition.toString();
+    await isolatedRedisClient.watch(watermarkKey);
+    const currentOffset = await isolatedRedisClient.hGet(watermarkKey, partitionField);
+
+    if (!isIncomingOffsetNewer(currentOffset, offset)) {
+      await isolatedRedisClient.unwatch();
+      return 'duplicate';
+    }
+
+    const transactionResult = await isolatedRedisClient.multi()
+      .rPush(messagesKey, serializedMessage)
+      .lTrim(messagesKey, -maxMessages, -1)
+      .hSet(watermarkKey, partitionField, offset)
+      .expire(messagesKey, ttlSeconds)
+      .expire(watermarkKey, ttlSeconds)
+      .exec();
+
+    if (transactionResult === null) {
+      return 'conflict';
+    }
+
+    return 'inserted';
+  });
+};
+
+export const isIncomingOffsetNewer = (
+  currentOffset: string | null | undefined,
+  incomingOffset: string,
+): boolean => {
+  if (!currentOffset) {
+    return true;
+  }
+  return compareOffsetStrings(incomingOffset, currentOffset) > 0;
+};
+
+export const compareOffsetStrings = (left: string, right: string): number => {
+  // Kafka offsets are 64-bit integers and can exceed Number.MAX_SAFE_INTEGER.
+  // Keep comparisons in string-space to avoid precision loss in JS numbers.
+  if (left.length !== right.length) {
+    return left.length - right.length;
+  }
+  if (left === right) {
+    return 0;
+  }
+  return left > right ? 1 : -1;
+};
+
+const getWatchConflictBackoffMs = (): number => {
+  return Math.floor(
+    Math.random() * (WATCH_CONFLICT_BACKOFF_MAX_MS - WATCH_CONFLICT_BACKOFF_MIN_MS + 1),
+  ) + WATCH_CONFLICT_BACKOFF_MIN_MS;
+};
+
+const sleep = async (ms: number): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};

--- a/src/kafka/subscribers/redis-topic-dedupe.ts
+++ b/src/kafka/subscribers/redis-topic-dedupe.ts
@@ -1,7 +1,6 @@
 import { RedisClient } from '../../redis/types';
 
 type AppendResult = 'inserted' | 'duplicate';
-type AppendAttemptResult = AppendResult | 'conflict';
 
 type AppendTopicMessageParams = {
   maxMessages: number;
@@ -14,25 +13,7 @@ type AppendTopicMessageParams = {
   watermarkKey: string;
 };
 
-const WATCH_CONFLICT_MAX_RETRIES = 8;
-const WATCH_CONFLICT_BACKOFF_MIN_MS = 5;
-const WATCH_CONFLICT_BACKOFF_MAX_MS = 30;
-
 export const appendTopicMessageWithDedupe = async (
-  params: AppendTopicMessageParams,
-): Promise<AppendResult> => {
-  for (let attempt = 1; attempt <= WATCH_CONFLICT_MAX_RETRIES; attempt += 1) {
-    const result = await attemptAtomicAppendWithWatch(params);
-    if (result !== 'conflict') {
-      return result;
-    }
-    await sleep(getWatchConflictBackoffMs());
-  }
-
-  throw new Error(`Failed to append deduped topic message after ${WATCH_CONFLICT_MAX_RETRIES} WATCH conflicts`);
-};
-
-const attemptAtomicAppendWithWatch = async (
   {
     maxMessages,
     messagesKey,
@@ -43,31 +24,23 @@ const attemptAtomicAppendWithWatch = async (
     ttlSeconds,
     watermarkKey,
   }: AppendTopicMessageParams,
-): Promise<AppendAttemptResult> => {
-  return await redisClient.executeIsolated(async (isolatedRedisClient) => {
-    const partitionField = partition.toString();
-    await isolatedRedisClient.watch(watermarkKey);
-    const currentOffset = await isolatedRedisClient.hGet(watermarkKey, partitionField);
+): Promise<AppendResult> => {
+  const partitionField = partition.toString();
+  const currentOffset = await redisClient.hGet(watermarkKey, partitionField);
 
-    if (!isIncomingOffsetNewer(currentOffset, offset)) {
-      await isolatedRedisClient.unwatch();
-      return 'duplicate';
-    }
+  if (!isIncomingOffsetNewer(currentOffset, offset)) {
+    return 'duplicate';
+  }
 
-    const transactionResult = await isolatedRedisClient.multi()
-      .rPush(messagesKey, serializedMessage)
-      .lTrim(messagesKey, -maxMessages, -1)
-      .hSet(watermarkKey, partitionField, offset)
-      .expire(messagesKey, ttlSeconds)
-      .expire(watermarkKey, ttlSeconds)
-      .exec();
+  await redisClient.multi()
+    .rPush(messagesKey, serializedMessage)
+    .lTrim(messagesKey, -maxMessages, -1)
+    .hSet(watermarkKey, partitionField, offset)
+    .expire(messagesKey, ttlSeconds)
+    .expire(watermarkKey, ttlSeconds)
+    .exec();
 
-    if (transactionResult === null) {
-      return 'conflict';
-    }
-
-    return 'inserted';
-  });
+  return 'inserted';
 };
 
 export const isIncomingOffsetNewer = (
@@ -90,16 +63,4 @@ export const compareOffsetStrings = (left: string, right: string): number => {
     return 0;
   }
   return left > right ? 1 : -1;
-};
-
-const getWatchConflictBackoffMs = (): number => {
-  return Math.floor(
-    Math.random() * (WATCH_CONFLICT_BACKOFF_MAX_MS - WATCH_CONFLICT_BACKOFF_MIN_MS + 1),
-  ) + WATCH_CONFLICT_BACKOFF_MIN_MS;
-};
-
-const sleep = async (ms: number): Promise<void> => {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
 };

--- a/src/kafka/subscribers/subscriber.ts
+++ b/src/kafka/subscribers/subscriber.ts
@@ -78,6 +78,10 @@ export class Subscriber {
     });
     await assignPartitions(this.consumer, partitions, this.topic);
   }
+
+  protected get1MinuteAgoTimestamp(): number {
+    return get1MinuteAgoTimestamp();
+  }
 }
 
 const getPartitionsByTimestamp = async (

--- a/src/kafka/subscribers/topic-consumers-manager/index.ts
+++ b/src/kafka/subscribers/topic-consumers-manager/index.ts
@@ -7,7 +7,7 @@ import {
   TOPIC_LEADER_LOCK_RENEW_INTERVAL_MS,
   TOPIC_LEADER_LOCK_TTL_SECONDS,
 } from '../constants';
-import { toTopicLeaderKey } from '../redis-keys';
+import { toTopicLeaderKey, toTopicMessagesKey } from '../redis-keys';
 import { RedisSubscriber } from '../redis-subscriber';
 
 type TopicEntry = {
@@ -35,6 +35,12 @@ export const ensureTopicConsumerRunning = async (
     }
 
     if (existing?.consumer) {
+      if (timestamp != null) {
+        const count = await getRedisClient().lLen(toTopicMessagesKey(topic));
+        if (count === 0) {
+          await existing.consumer.reseekToTimestamp(timestamp);
+        }
+      }
       return;
     }
 

--- a/test/kafka/redis-subscriber.test.ts
+++ b/test/kafka/redis-subscriber.test.ts
@@ -114,3 +114,64 @@ describe('RedisSubscriber.reseekToTimestamp', () => {
     expect(redisClient.del).toHaveBeenCalledWith(watermarkKey);
   });
 });
+
+describe('RedisSubscriber.subscribeAsTopicConsumer', () => {
+  const subscribeParams = { brokers: ['kafka:9092'], topic: 'test-topic' };
+
+  const makeKafka = (partitions: { offset: string; partition: number }[]) => {
+    const admin = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      fetchTopicOffsetsByTimestamp: jest.fn().mockResolvedValue(partitions),
+    };
+    return { _admin: admin, admin: jest.fn().mockReturnValue(admin) };
+  };
+
+  const makeRedisClient = () => ({ del: jest.fn().mockResolvedValue(1) });
+
+  const createSubscriber = () => {
+    mockGetRedisClient.mockReturnValue(makeRedisClient() as never);
+    return new RedisSubscriber(subscribeParams, {});
+  };
+
+  it('seeks from one minute ago when timestamp is not provided', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    try {
+      const consumer = {
+        connect: jest.fn().mockResolvedValue(undefined),
+        run: jest.fn().mockResolvedValue(undefined),
+        seek: jest.fn(),
+        subscribe: jest.fn().mockResolvedValue(undefined),
+      };
+      const { _admin: admin, admin: kafkaAdmin } = makeKafka([{ offset: '5', partition: 0 }]);
+      const subscriber = createSubscriber();
+      subscriber.consumer = consumer as never;
+      subscriber.kafka = { admin: kafkaAdmin } as never;
+
+      await subscriber.subscribeAsTopicConsumer(undefined);
+
+      expect(admin.fetchTopicOffsetsByTimestamp).toHaveBeenCalledWith('test-topic', 1699999940000);
+      expect(consumer.seek).toHaveBeenCalledWith({ offset: '5', partition: 0, topic: 'test-topic' });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('uses explicit timestamp when provided', async () => {
+    const consumer = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      run: jest.fn().mockResolvedValue(undefined),
+      seek: jest.fn(),
+      subscribe: jest.fn().mockResolvedValue(undefined),
+    };
+    const { _admin: admin, admin: kafkaAdmin } = makeKafka([{ offset: '7', partition: 1 }]);
+    const subscriber = createSubscriber();
+    subscriber.consumer = consumer as never;
+    subscriber.kafka = { admin: kafkaAdmin } as never;
+
+    await subscriber.subscribeAsTopicConsumer(1234567890000);
+
+    expect(admin.fetchTopicOffsetsByTimestamp).toHaveBeenCalledWith('test-topic', 1234567890000);
+    expect(consumer.seek).toHaveBeenCalledWith({ offset: '7', partition: 1, topic: 'test-topic' });
+  });
+});

--- a/test/kafka/redis-subscriber.test.ts
+++ b/test/kafka/redis-subscriber.test.ts
@@ -1,0 +1,116 @@
+import { RedisSubscriber } from '../../src/kafka/subscribers/redis-subscriber';
+import { getRedisClient } from '../../src/redis/redis-client';
+
+jest.mock('../../src/redis/redis-client');
+jest.mock('../../src/multi-instance', () => ({ thisRelayInstanceId: 'test-instance' }));
+jest.mock('../../src/kafka/subscribers/topic-consumers-manager', () => ({
+  ensureTopicConsumerRunning: jest.fn(),
+}));
+jest.mock('../../src/kafka/schema-registry', () => ({ decode: jest.fn().mockResolvedValue(undefined) }));
+
+const mockGetRedisClient = getRedisClient as jest.MockedFunction<typeof getRedisClient>;
+
+describe('RedisSubscriber.reseekToTimestamp', () => {
+  const subscribeParams = { brokers: ['kafka:9092'], topic: 'test-topic' };
+  const watermarkKey = 'kafka-relay:topics:test-topic:partition-offset-watermarks';
+
+  const makeConsumer = () => ({ seek: jest.fn() });
+
+  const makeKafka = (partitions: { offset: string; partition: number }[]) => {
+    const admin = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      fetchTopicOffsetsByTimestamp: jest.fn().mockResolvedValue(partitions),
+    };
+    return { _admin: admin, admin: jest.fn().mockReturnValue(admin) };
+  };
+
+  const makeRedisClient = () => ({ del: jest.fn().mockResolvedValue(1) });
+
+  const createSubscriber = (redisClient: ReturnType<typeof makeRedisClient>) => {
+    mockGetRedisClient.mockReturnValue(redisClient as never);
+    // asTopicConsumer defaults to false → consumer and kafka are left undefined
+    return new RedisSubscriber(subscribeParams, {});
+  };
+
+  it('throws when consumer is not initialized', async () => {
+    const subscriber = createSubscriber(makeRedisClient());
+    // kafka is also undefined, but the guard checks both together
+    await expect(subscriber.reseekToTimestamp(12345)).rejects.toThrow(
+      'Kafka consumer is not initialized',
+    );
+  });
+
+  it('throws when kafka is not initialized', async () => {
+    const subscriber = createSubscriber(makeRedisClient());
+    subscriber.consumer = makeConsumer() as never;
+    // kafka is still undefined
+    await expect(subscriber.reseekToTimestamp(12345)).rejects.toThrow(
+      'Kafka consumer is not initialized',
+    );
+  });
+
+  it('deletes the watermark key before seeking any partition', async () => {
+    const callOrder: string[] = [];
+    const redisClient = {
+      del: jest.fn().mockImplementation(() => {
+        callOrder.push('del');
+        return Promise.resolve(1);
+      }),
+    };
+    const consumer = {
+      seek: jest.fn().mockImplementation(() => {
+        callOrder.push('seek');
+      }),
+    };
+    const { _admin: admin, admin: kafkaAdmin } = makeKafka([{ offset: '5', partition: 0 }]);
+    admin.fetchTopicOffsetsByTimestamp.mockResolvedValue([{ offset: '5', partition: 0 }]);
+
+    const subscriber = createSubscriber(redisClient as never);
+    subscriber.consumer = consumer as never;
+    subscriber.kafka = { admin: kafkaAdmin } as never;
+
+    await subscriber.reseekToTimestamp(1000);
+
+    expect(callOrder[0]).toBe('del');
+    expect(callOrder).toContain('seek');
+    expect(redisClient.del).toHaveBeenCalledWith(watermarkKey);
+  });
+
+  it('seeks every partition returned by the admin client', async () => {
+    const redisClient = makeRedisClient();
+    const consumer = makeConsumer();
+    const partitions = [
+      { offset: '10', partition: 0 },
+      { offset: '20', partition: 1 },
+      { offset: '30', partition: 2 },
+    ];
+    const { _admin: admin, admin: kafkaAdmin } = makeKafka(partitions);
+
+    const subscriber = createSubscriber(redisClient as never);
+    subscriber.consumer = consumer as never;
+    subscriber.kafka = { admin: kafkaAdmin } as never;
+
+    await subscriber.reseekToTimestamp(99999);
+
+    expect(admin.fetchTopicOffsetsByTimestamp).toHaveBeenCalledWith('test-topic', 99999);
+    expect(consumer.seek).toHaveBeenCalledTimes(3);
+    expect(consumer.seek).toHaveBeenCalledWith({ offset: '10', partition: 0, topic: 'test-topic' });
+    expect(consumer.seek).toHaveBeenCalledWith({ offset: '20', partition: 1, topic: 'test-topic' });
+    expect(consumer.seek).toHaveBeenCalledWith({ offset: '30', partition: 2, topic: 'test-topic' });
+  });
+
+  it('deletes watermark for the correct topic key', async () => {
+    const redisClient = makeRedisClient();
+    const { admin: kafkaAdmin } = makeKafka([{ offset: '0', partition: 0 }]);
+
+    const subscriber = createSubscriber(redisClient as never);
+    subscriber.consumer = makeConsumer() as never;
+    subscriber.kafka = { admin: kafkaAdmin } as never;
+
+    await subscriber.reseekToTimestamp(1000);
+
+    expect(redisClient.del).toHaveBeenCalledTimes(1);
+    expect(redisClient.del).toHaveBeenCalledWith(watermarkKey);
+  });
+});

--- a/test/kafka/redis-topic-dedupe.integration.test.ts
+++ b/test/kafka/redis-topic-dedupe.integration.test.ts
@@ -10,7 +10,10 @@ type StoredMessage = {
   value: string;
 };
 
-describe('redis topic dedupe integration', () => {
+const runRedisIntegrationTests = process.env.RUN_REDIS_INTEGRATION_TESTS === 'true';
+const describeRedisIntegration = runRedisIntegrationTests ? describe : describe.skip;
+
+describeRedisIntegration('redis topic dedupe integration', () => {
   const TEST_TTL_SECONDS = 5;
   const redisClient = createClient({
     url: process.env.REDIS_URL || 'redis://localhost:6379',

--- a/test/kafka/redis-topic-dedupe.integration.test.ts
+++ b/test/kafka/redis-topic-dedupe.integration.test.ts
@@ -35,41 +35,55 @@ describeRedisIntegration('redis topic dedupe integration', () => {
     await redisClient.disconnect();
   });
 
-  it('stores only one message for many concurrent writes of the same partition+offset', async () => {
+  it('dedupes repeated sequential writes for the same partition+offset', async () => {
     const topic = `it-dedupe-${randomUUID()}`;
     const messagesKey = toTopicMessagesKey(topic);
     const watermarkKey = toTopicPartitionOffsetWatermarksKey(topic);
     await redisClient.del([messagesKey, watermarkKey]);
 
-    const calls = Array.from({ length: 100 }, (_, i) =>
-      appendTopicMessageWithDedupe({
-        maxMessages: 5000,
-        messagesKey,
+    const first = await appendTopicMessageWithDedupe({
+      maxMessages: 5000,
+      messagesKey,
+      offset: '500',
+      partition: 0,
+      redisClient,
+      serializedMessage: JSON.stringify({
         offset: '500',
         partition: 0,
-        redisClient,
-        serializedMessage: JSON.stringify({
-          offset: '500',
-          partition: 0,
-          value: `payload-${i}`,
-        }),
-        ttlSeconds: TEST_TTL_SECONDS,
-        watermarkKey,
+        value: 'payload-1',
       }),
-    );
+      ttlSeconds: TEST_TTL_SECONDS,
+      watermarkKey,
+    });
 
-    await Promise.all(calls);
+    const second = await appendTopicMessageWithDedupe({
+      maxMessages: 5000,
+      messagesKey,
+      offset: '500',
+      partition: 0,
+      redisClient,
+      serializedMessage: JSON.stringify({
+        offset: '500',
+        partition: 0,
+        value: 'payload-2',
+      }),
+      ttlSeconds: TEST_TTL_SECONDS,
+      watermarkKey,
+    });
 
     const [serializedMessages, watermark] = await Promise.all([
       redisClient.lRange(messagesKey, 0, -1),
       redisClient.hGet(watermarkKey, '0'),
     ]);
 
+    expect(first).toBe('inserted');
+    expect(second).toBe('duplicate');
     expect(serializedMessages).toHaveLength(1);
     expect(watermark).toBe('500');
     const parsed = JSON.parse(serializedMessages[0]) as StoredMessage;
     expect(parsed.partition).toBe(0);
     expect(parsed.offset).toBe('500');
+    expect(parsed.value).toBe('payload-1');
   });
 
   it('dedupes per partition (same offset can be inserted once in each partition)', async () => {
@@ -78,34 +92,47 @@ describeRedisIntegration('redis topic dedupe integration', () => {
     const watermarkKey = toTopicPartitionOffsetWatermarksKey(topic);
     await redisClient.del([messagesKey, watermarkKey]);
 
-    const calls = [
-      ...Array.from({ length: 50 }, (_, i) =>
-        appendTopicMessageWithDedupe({
-          maxMessages: 5000,
-          messagesKey,
-          offset: '42',
-          partition: 0,
-          redisClient,
-          serializedMessage: JSON.stringify({ offset: '42', partition: 0, value: `p0-${i}` }),
-          ttlSeconds: TEST_TTL_SECONDS,
-          watermarkKey,
-        }),
-      ),
-      ...Array.from({ length: 50 }, (_, i) =>
-        appendTopicMessageWithDedupe({
-          maxMessages: 5000,
-          messagesKey,
-          offset: '42',
-          partition: 1,
-          redisClient,
-          serializedMessage: JSON.stringify({ offset: '42', partition: 1, value: `p1-${i}` }),
-          ttlSeconds: TEST_TTL_SECONDS,
-          watermarkKey,
-        }),
-      ),
-    ];
-
-    await Promise.all(calls);
+    const results = [];
+    results.push(await appendTopicMessageWithDedupe({
+      maxMessages: 5000,
+      messagesKey,
+      offset: '42',
+      partition: 0,
+      redisClient,
+      serializedMessage: JSON.stringify({ offset: '42', partition: 0, value: 'p0' }),
+      ttlSeconds: TEST_TTL_SECONDS,
+      watermarkKey,
+    }));
+    results.push(await appendTopicMessageWithDedupe({
+      maxMessages: 5000,
+      messagesKey,
+      offset: '42',
+      partition: 1,
+      redisClient,
+      serializedMessage: JSON.stringify({ offset: '42', partition: 1, value: 'p1' }),
+      ttlSeconds: TEST_TTL_SECONDS,
+      watermarkKey,
+    }));
+    results.push(await appendTopicMessageWithDedupe({
+      maxMessages: 5000,
+      messagesKey,
+      offset: '42',
+      partition: 0,
+      redisClient,
+      serializedMessage: JSON.stringify({ offset: '42', partition: 0, value: 'p0-dup' }),
+      ttlSeconds: TEST_TTL_SECONDS,
+      watermarkKey,
+    }));
+    results.push(await appendTopicMessageWithDedupe({
+      maxMessages: 5000,
+      messagesKey,
+      offset: '42',
+      partition: 1,
+      redisClient,
+      serializedMessage: JSON.stringify({ offset: '42', partition: 1, value: 'p1-dup' }),
+      ttlSeconds: TEST_TTL_SECONDS,
+      watermarkKey,
+    }));
 
     const [serializedMessages, watermark0, watermark1] = await Promise.all([
       redisClient.lRange(messagesKey, 0, -1),
@@ -113,6 +140,7 @@ describeRedisIntegration('redis topic dedupe integration', () => {
       redisClient.hGet(watermarkKey, '1'),
     ]);
 
+    expect(results).toEqual(['inserted', 'inserted', 'duplicate', 'duplicate']);
     expect(watermark0).toBe('42');
     expect(watermark1).toBe('42');
     expect(serializedMessages).toHaveLength(2);

--- a/test/kafka/redis-topic-dedupe.integration.test.ts
+++ b/test/kafka/redis-topic-dedupe.integration.test.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from 'crypto';
+
+import { createClient } from 'redis';
+
+import { appendTopicMessageWithDedupe } from '../../src/kafka/subscribers/redis-topic-dedupe';
+
+type StoredMessage = {
+  offset: string;
+  partition: number;
+  value: string;
+};
+
+describe('redis topic dedupe integration', () => {
+  const TEST_TTL_SECONDS = 5;
+  const redisClient = createClient({
+    url: process.env.REDIS_URL || 'redis://localhost:6379',
+  });
+
+  jest.setTimeout(20000);
+
+  const toTopicMessagesKey = (topic: string): string =>
+    `kafka-relay:topics:${encodeURIComponent(topic)}:messages`;
+
+  const toTopicPartitionOffsetWatermarksKey = (topic: string): string =>
+    `kafka-relay:topics:${encodeURIComponent(topic)}:partition-offset-watermarks`;
+
+  beforeAll(async () => {
+    await redisClient.connect();
+  });
+
+  afterAll(async () => {
+    await redisClient.disconnect();
+  });
+
+  it('stores only one message for many concurrent writes of the same partition+offset', async () => {
+    const topic = `it-dedupe-${randomUUID()}`;
+    const messagesKey = toTopicMessagesKey(topic);
+    const watermarkKey = toTopicPartitionOffsetWatermarksKey(topic);
+    await redisClient.del([messagesKey, watermarkKey]);
+
+    const calls = Array.from({ length: 100 }, (_, i) =>
+      appendTopicMessageWithDedupe({
+        maxMessages: 5000,
+        messagesKey,
+        offset: '500',
+        partition: 0,
+        redisClient,
+        serializedMessage: JSON.stringify({
+          offset: '500',
+          partition: 0,
+          value: `payload-${i}`,
+        }),
+        ttlSeconds: TEST_TTL_SECONDS,
+        watermarkKey,
+      }),
+    );
+
+    await Promise.all(calls);
+
+    const [serializedMessages, watermark] = await Promise.all([
+      redisClient.lRange(messagesKey, 0, -1),
+      redisClient.hGet(watermarkKey, '0'),
+    ]);
+
+    expect(serializedMessages).toHaveLength(1);
+    expect(watermark).toBe('500');
+    const parsed = JSON.parse(serializedMessages[0]) as StoredMessage;
+    expect(parsed.partition).toBe(0);
+    expect(parsed.offset).toBe('500');
+  });
+
+  it('dedupes per partition (same offset can be inserted once in each partition)', async () => {
+    const topic = `it-dedupe-${randomUUID()}`;
+    const messagesKey = toTopicMessagesKey(topic);
+    const watermarkKey = toTopicPartitionOffsetWatermarksKey(topic);
+    await redisClient.del([messagesKey, watermarkKey]);
+
+    const calls = [
+      ...Array.from({ length: 50 }, (_, i) =>
+        appendTopicMessageWithDedupe({
+          maxMessages: 5000,
+          messagesKey,
+          offset: '42',
+          partition: 0,
+          redisClient,
+          serializedMessage: JSON.stringify({ offset: '42', partition: 0, value: `p0-${i}` }),
+          ttlSeconds: TEST_TTL_SECONDS,
+          watermarkKey,
+        }),
+      ),
+      ...Array.from({ length: 50 }, (_, i) =>
+        appendTopicMessageWithDedupe({
+          maxMessages: 5000,
+          messagesKey,
+          offset: '42',
+          partition: 1,
+          redisClient,
+          serializedMessage: JSON.stringify({ offset: '42', partition: 1, value: `p1-${i}` }),
+          ttlSeconds: TEST_TTL_SECONDS,
+          watermarkKey,
+        }),
+      ),
+    ];
+
+    await Promise.all(calls);
+
+    const [serializedMessages, watermark0, watermark1] = await Promise.all([
+      redisClient.lRange(messagesKey, 0, -1),
+      redisClient.hGet(watermarkKey, '0'),
+      redisClient.hGet(watermarkKey, '1'),
+    ]);
+
+    expect(watermark0).toBe('42');
+    expect(watermark1).toBe('42');
+    expect(serializedMessages).toHaveLength(2);
+    const uniquePartitionOffsets = new Set(
+      serializedMessages.map((message) => {
+        const parsed = JSON.parse(message) as StoredMessage;
+        return `${parsed.partition}:${parsed.offset}`;
+      }),
+    );
+    expect(uniquePartitionOffsets.size).toBe(2);
+  });
+});

--- a/test/kafka/redis-topic-dedupe.test.ts
+++ b/test/kafka/redis-topic-dedupe.test.ts
@@ -55,23 +55,16 @@ describe('redis topic dedupe offset comparisons', () => {
     };
 
     type MockTxn = {
-      exec: jest.Mock<Promise<unknown[] | null>, []>;
+      exec: jest.Mock<Promise<unknown[]>, []>;
       expire: jest.Mock<MockTxn, [string, number]>;
       hSet: jest.Mock<MockTxn, [string, string, string]>;
       lTrim: jest.Mock<MockTxn, [string, number, number]>;
       rPush: jest.Mock<MockTxn, [string, string]>;
     };
 
-    type MockIsolatedClient = {
-      hGet: jest.Mock<Promise<string | null>, [string, string]>;
-      multi: jest.Mock<MockTxn, []>;
-      unwatch?: jest.Mock<Promise<void>, []>;
-      watch: jest.Mock<Promise<void>, [string]>;
-    };
-
-    const createTxn = (execResult: unknown[] | null): MockTxn => {
+    const createTxn = (): MockTxn => {
       const txn = {
-        exec: jest.fn<Promise<unknown[] | null>, []>().mockResolvedValue(execResult),
+        exec: jest.fn<Promise<unknown[]>, []>().mockResolvedValue(['OK']),
         expire: jest.fn<MockTxn, [string, number]>(),
         hSet: jest.fn<MockTxn, [string, string, string]>(),
         lTrim: jest.fn<MockTxn, [string, number, number]>(),
@@ -84,32 +77,11 @@ describe('redis topic dedupe offset comparisons', () => {
       return txn;
     };
 
-    const createRedisClient = (clients: MockIsolatedClient[]) => {
-      const executeIsolated = jest.fn(async (
-        cb: (isolatedClient: MockIsolatedClient) => Promise<unknown>,
-      ) => {
-        const isolatedClient = clients.shift();
-        if (!isolatedClient) {
-          throw new Error('No mock isolated client left');
-        }
-        return await cb(isolatedClient);
-      });
-      return {
-        executeIsolated,
-      };
-    };
-
     it('returns duplicate and skips transaction when offset is not newer', async () => {
-      const watch = jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined);
+      const txn = createTxn();
       const hGet = jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29123');
-      const unwatch = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
-      const multi = jest.fn<MockTxn, []>();
-      const redisClient = createRedisClient([{
-        hGet,
-        multi,
-        unwatch,
-        watch,
-      }]);
+      const multi = jest.fn<MockTxn, []>().mockReturnValue(txn);
+      const redisClient = { hGet, multi };
 
       const result = await appendTopicMessageWithDedupe({
         ...baseParams,
@@ -117,18 +89,16 @@ describe('redis topic dedupe offset comparisons', () => {
       });
 
       expect(result).toBe('duplicate');
-      expect(watch).toHaveBeenCalledWith(baseParams.watermarkKey);
       expect(hGet).toHaveBeenCalledWith(baseParams.watermarkKey, '0');
-      expect(unwatch).toHaveBeenCalledTimes(1);
       expect(multi).not.toHaveBeenCalled();
+      expect(txn.exec).not.toHaveBeenCalled();
     });
 
     it('inserts message when offset is newer', async () => {
-      const txn = createTxn(['OK']);
-      const watch = jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined);
+      const txn = createTxn();
       const hGet = jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122');
       const multi = jest.fn<MockTxn, []>().mockReturnValue(txn);
-      const redisClient = createRedisClient([{ hGet, multi, watch }]);
+      const redisClient = { hGet, multi };
 
       const result = await appendTopicMessageWithDedupe({
         ...baseParams,
@@ -136,63 +106,13 @@ describe('redis topic dedupe offset comparisons', () => {
       });
 
       expect(result).toBe('inserted');
+      expect(hGet).toHaveBeenCalledWith(baseParams.watermarkKey, '0');
       expect(txn.rPush).toHaveBeenCalledWith(baseParams.messagesKey, baseParams.serializedMessage);
       expect(txn.lTrim).toHaveBeenCalledWith(baseParams.messagesKey, -baseParams.maxMessages, -1);
       expect(txn.hSet).toHaveBeenCalledWith(baseParams.watermarkKey, '0', baseParams.offset);
       expect(txn.expire).toHaveBeenNthCalledWith(1, baseParams.messagesKey, baseParams.ttlSeconds);
       expect(txn.expire).toHaveBeenNthCalledWith(2, baseParams.watermarkKey, baseParams.ttlSeconds);
       expect(txn.exec).toHaveBeenCalledTimes(1);
-    });
-
-    it('retries once after WATCH conflict and then inserts', async () => {
-      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
-      try {
-        const firstTxn = createTxn(null);
-        const secondTxn = createTxn(['OK']);
-        const redisClient = createRedisClient([
-          {
-            hGet: jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122'),
-            multi: jest.fn<MockTxn, []>().mockReturnValue(firstTxn),
-            watch: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
-          },
-          {
-            hGet: jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122'),
-            multi: jest.fn<MockTxn, []>().mockReturnValue(secondTxn),
-            watch: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
-          },
-        ]);
-
-        const result = await appendTopicMessageWithDedupe({
-          ...baseParams,
-          redisClient: redisClient as unknown as Parameters<typeof appendTopicMessageWithDedupe>[0]['redisClient'],
-        });
-
-        expect(result).toBe('inserted');
-        expect(redisClient.executeIsolated).toHaveBeenCalledTimes(2);
-        expect(firstTxn.exec).toHaveBeenCalledTimes(1);
-        expect(secondTxn.exec).toHaveBeenCalledTimes(1);
-      } finally {
-        randomSpy.mockRestore();
-      }
-    });
-
-    it('throws after exhausting WATCH conflict retries', async () => {
-      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
-      try {
-        const redisClient = createRedisClient(Array.from({ length: 8 }, () => ({
-          hGet: jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122'),
-          multi: jest.fn<MockTxn, []>().mockReturnValue(createTxn(null)),
-          watch: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
-        })));
-
-        await expect(appendTopicMessageWithDedupe({
-          ...baseParams,
-          redisClient: redisClient as unknown as Parameters<typeof appendTopicMessageWithDedupe>[0]['redisClient'],
-        })).rejects.toThrow('Failed to append deduped topic message after 8 WATCH conflicts');
-        expect(redisClient.executeIsolated).toHaveBeenCalledTimes(8);
-      } finally {
-        randomSpy.mockRestore();
-      }
     });
   });
 });

--- a/test/kafka/redis-topic-dedupe.test.ts
+++ b/test/kafka/redis-topic-dedupe.test.ts
@@ -1,0 +1,198 @@
+import {
+  appendTopicMessageWithDedupe,
+  compareOffsetStrings,
+  isIncomingOffsetNewer,
+} from '../../src/kafka/subscribers/redis-topic-dedupe';
+
+describe('redis topic dedupe offset comparisons', () => {
+  describe('compareOffsetStrings', () => {
+    it('returns 0 for equal offsets', () => {
+      expect(compareOffsetStrings('29123', '29123')).toBe(0);
+    });
+
+    it('returns positive number when left is greater', () => {
+      expect(compareOffsetStrings('29124', '29123')).toBeGreaterThan(0);
+    });
+
+    it('returns negative number when left is smaller', () => {
+      expect(compareOffsetStrings('29122', '29123')).toBeLessThan(0);
+    });
+
+    it('compares large integer-strings safely', () => {
+      const current = '18446744073709551614';
+      const incoming = '18446744073709551615';
+      expect(compareOffsetStrings(incoming, current)).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isIncomingOffsetNewer', () => {
+    it('accepts first offset when no watermark exists', () => {
+      expect(isIncomingOffsetNewer(null, '1')).toBe(true);
+    });
+
+    it('rejects same offset as duplicate', () => {
+      expect(isIncomingOffsetNewer('120', '120')).toBe(false);
+    });
+
+    it('rejects lower offset as duplicate', () => {
+      expect(isIncomingOffsetNewer('120', '119')).toBe(false);
+    });
+
+    it('accepts higher offset', () => {
+      expect(isIncomingOffsetNewer('120', '121')).toBe(true);
+    });
+  });
+
+  describe('appendTopicMessageWithDedupe', () => {
+    const baseParams = {
+      maxMessages: 5000,
+      messagesKey: 'kafka-relay:topics:test-topic:messages',
+      offset: '29123',
+      partition: 0,
+      serializedMessage: '{"offset":"29123","partition":0}',
+      ttlSeconds: 600,
+      watermarkKey: 'kafka-relay:topics:test-topic:partition-offset-watermarks',
+    };
+
+    type MockTxn = {
+      exec: jest.Mock<Promise<unknown[] | null>, []>;
+      expire: jest.Mock<MockTxn, [string, number]>;
+      hSet: jest.Mock<MockTxn, [string, string, string]>;
+      lTrim: jest.Mock<MockTxn, [string, number, number]>;
+      rPush: jest.Mock<MockTxn, [string, string]>;
+    };
+
+    type MockIsolatedClient = {
+      hGet: jest.Mock<Promise<string | null>, [string, string]>;
+      multi: jest.Mock<MockTxn, []>;
+      unwatch?: jest.Mock<Promise<void>, []>;
+      watch: jest.Mock<Promise<void>, [string]>;
+    };
+
+    const createTxn = (execResult: unknown[] | null): MockTxn => {
+      const txn = {
+        exec: jest.fn<Promise<unknown[] | null>, []>().mockResolvedValue(execResult),
+        expire: jest.fn<MockTxn, [string, number]>(),
+        hSet: jest.fn<MockTxn, [string, string, string]>(),
+        lTrim: jest.fn<MockTxn, [string, number, number]>(),
+        rPush: jest.fn<MockTxn, [string, string]>(),
+      };
+      txn.rPush.mockReturnValue(txn);
+      txn.lTrim.mockReturnValue(txn);
+      txn.hSet.mockReturnValue(txn);
+      txn.expire.mockReturnValue(txn);
+      return txn;
+    };
+
+    const createRedisClient = (clients: MockIsolatedClient[]) => {
+      const executeIsolated = jest.fn(async (
+        cb: (isolatedClient: MockIsolatedClient) => Promise<unknown>,
+      ) => {
+        const isolatedClient = clients.shift();
+        if (!isolatedClient) {
+          throw new Error('No mock isolated client left');
+        }
+        return await cb(isolatedClient);
+      });
+      return {
+        executeIsolated,
+      };
+    };
+
+    it('returns duplicate and skips transaction when offset is not newer', async () => {
+      const watch = jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined);
+      const hGet = jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29123');
+      const unwatch = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+      const multi = jest.fn<MockTxn, []>();
+      const redisClient = createRedisClient([{
+        hGet,
+        multi,
+        unwatch,
+        watch,
+      }]);
+
+      const result = await appendTopicMessageWithDedupe({
+        ...baseParams,
+        redisClient: redisClient as unknown as Parameters<typeof appendTopicMessageWithDedupe>[0]['redisClient'],
+      });
+
+      expect(result).toBe('duplicate');
+      expect(watch).toHaveBeenCalledWith(baseParams.watermarkKey);
+      expect(hGet).toHaveBeenCalledWith(baseParams.watermarkKey, '0');
+      expect(unwatch).toHaveBeenCalledTimes(1);
+      expect(multi).not.toHaveBeenCalled();
+    });
+
+    it('inserts message when offset is newer', async () => {
+      const txn = createTxn(['OK']);
+      const watch = jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined);
+      const hGet = jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122');
+      const multi = jest.fn<MockTxn, []>().mockReturnValue(txn);
+      const redisClient = createRedisClient([{ hGet, multi, watch }]);
+
+      const result = await appendTopicMessageWithDedupe({
+        ...baseParams,
+        redisClient: redisClient as unknown as Parameters<typeof appendTopicMessageWithDedupe>[0]['redisClient'],
+      });
+
+      expect(result).toBe('inserted');
+      expect(txn.rPush).toHaveBeenCalledWith(baseParams.messagesKey, baseParams.serializedMessage);
+      expect(txn.lTrim).toHaveBeenCalledWith(baseParams.messagesKey, -baseParams.maxMessages, -1);
+      expect(txn.hSet).toHaveBeenCalledWith(baseParams.watermarkKey, '0', baseParams.offset);
+      expect(txn.expire).toHaveBeenNthCalledWith(1, baseParams.messagesKey, baseParams.ttlSeconds);
+      expect(txn.expire).toHaveBeenNthCalledWith(2, baseParams.watermarkKey, baseParams.ttlSeconds);
+      expect(txn.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries once after WATCH conflict and then inserts', async () => {
+      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+      try {
+        const firstTxn = createTxn(null);
+        const secondTxn = createTxn(['OK']);
+        const redisClient = createRedisClient([
+          {
+            hGet: jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122'),
+            multi: jest.fn<MockTxn, []>().mockReturnValue(firstTxn),
+            watch: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
+          },
+          {
+            hGet: jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122'),
+            multi: jest.fn<MockTxn, []>().mockReturnValue(secondTxn),
+            watch: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
+          },
+        ]);
+
+        const result = await appendTopicMessageWithDedupe({
+          ...baseParams,
+          redisClient: redisClient as unknown as Parameters<typeof appendTopicMessageWithDedupe>[0]['redisClient'],
+        });
+
+        expect(result).toBe('inserted');
+        expect(redisClient.executeIsolated).toHaveBeenCalledTimes(2);
+        expect(firstTxn.exec).toHaveBeenCalledTimes(1);
+        expect(secondTxn.exec).toHaveBeenCalledTimes(1);
+      } finally {
+        randomSpy.mockRestore();
+      }
+    });
+
+    it('throws after exhausting WATCH conflict retries', async () => {
+      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+      try {
+        const redisClient = createRedisClient(Array.from({ length: 8 }, () => ({
+          hGet: jest.fn<Promise<string | null>, [string, string]>().mockResolvedValue('29122'),
+          multi: jest.fn<MockTxn, []>().mockReturnValue(createTxn(null)),
+          watch: jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined),
+        })));
+
+        await expect(appendTopicMessageWithDedupe({
+          ...baseParams,
+          redisClient: redisClient as unknown as Parameters<typeof appendTopicMessageWithDedupe>[0]['redisClient'],
+        })).rejects.toThrow('Failed to append deduped topic message after 8 WATCH conflicts');
+        expect(redisClient.executeIsolated).toHaveBeenCalledTimes(8);
+      } finally {
+        randomSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/test/kafka/topic-consumers-manager.test.ts
+++ b/test/kafka/topic-consumers-manager.test.ts
@@ -1,0 +1,76 @@
+import { ensureTopicConsumerRunning } from '../../src/kafka/subscribers/topic-consumers-manager';
+import { getRedisClient } from '../../src/redis/redis-client';
+
+// Prevent real Kafka/Redis connections
+jest.mock('../../src/redis/redis-client');
+jest.mock('../../src/multi-instance', () => ({ thisRelayInstanceId: 'test-instance' }));
+jest.mock('../../src/kafka/schema-registry', () => ({ decode: jest.fn().mockResolvedValue(undefined) }));
+
+// Mock RedisSubscriber so we control consumer creation and reseekToTimestamp
+const mockReseekToTimestamp = jest.fn().mockResolvedValue(undefined);
+const mockSubscribeAsTopicConsumer = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/kafka/subscribers/redis-subscriber', () => ({
+  RedisSubscriber: jest.fn().mockImplementation(() => ({
+    consumer: {},
+    reseekToTimestamp: mockReseekToTimestamp,
+    subscribeAsTopicConsumer: mockSubscribeAsTopicConsumer,
+  })),
+}));
+
+const mockGetRedisClient = getRedisClient as jest.MockedFunction<typeof getRedisClient>;
+
+const subscribeOptions = { connectionTimeout: undefined, sasl: undefined, ssl: false as const };
+
+// Each test uses a unique topic name so tests don't share the module-level topics Map state
+let topicCounter = 0;
+const nextTopic = () => `test-topic-${topicCounter++}`;
+
+describe('ensureTopicConsumerRunning', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when consumer is already running', () => {
+    const seedRunningConsumer = async (topic: string) => {
+      const mockRedisClient = { lLen: jest.fn().mockResolvedValue(1), set: jest.fn().mockResolvedValue('OK') };
+      mockGetRedisClient.mockReturnValue(mockRedisClient as never);
+      await ensureTopicConsumerRunning({ brokers: ['kafka:9092'], topic }, subscribeOptions);
+      jest.clearAllMocks();
+      return mockRedisClient;
+    };
+
+    it('re-seeks when timestamp is provided and messages key is empty', async () => {
+      const topic = nextTopic();
+      const redisClient = await seedRunningConsumer(topic);
+      redisClient.lLen.mockResolvedValue(0);
+      mockGetRedisClient.mockReturnValue(redisClient as never);
+
+      await ensureTopicConsumerRunning({ brokers: ['kafka:9092'], topic }, subscribeOptions, 99999);
+
+      expect(redisClient.lLen).toHaveBeenCalledWith(`kafka-relay:topics:${topic}:messages`);
+      expect(mockReseekToTimestamp).toHaveBeenCalledWith(99999);
+    });
+
+    it('does not re-seek when timestamp is provided but messages key is non-empty', async () => {
+      const topic = nextTopic();
+      const redisClient = await seedRunningConsumer(topic);
+      redisClient.lLen.mockResolvedValue(5);
+      mockGetRedisClient.mockReturnValue(redisClient as never);
+
+      await ensureTopicConsumerRunning({ brokers: ['kafka:9092'], topic }, subscribeOptions, 99999);
+
+      expect(mockReseekToTimestamp).not.toHaveBeenCalled();
+    });
+
+    it('does not read Redis or re-seek when no timestamp is given', async () => {
+      const topic = nextTopic();
+      const redisClient = await seedRunningConsumer(topic);
+      mockGetRedisClient.mockReturnValue(redisClient as never);
+
+      await ensureTopicConsumerRunning({ brokers: ['kafka:9092'], topic }, subscribeOptions, undefined);
+
+      expect(redisClient.lLen).not.toHaveBeenCalled();
+      expect(mockReseekToTimestamp).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# Avoid message duplication in Redis topic + fix timestamp replay

## Changes

### 1. Deduplicate messages in the shared Redis topic list (simplified)

In multi-instance deployments, relay instances can briefly overlap as leader for
the same topic during handover. To reduce duplicate appends, we now track the
last-seen offset per partition in a Redis hash
(`partition-offset-watermarks`).

For each message:
- Read current partition watermark
- If incoming offset is not newer -> skip as duplicate
- If newer -> append message, trim list, update watermark, and refresh TTLs in one `MULTI/EXEC`

### 2. Fix: `/subscribe` with `timestamp` was silently ignored when a consumer was already running

Any running consumer ignored the timestamp provided by the subscriber — the
consumer stayed at its current position regardless. This was most visible when
the Redis `messages` key had expired (10 min TTL), causing `/consume` to return
404, but the incorrect positioning affected all timestamped subscribes against a
running consumer.

Two bugs, two fixes:

**Fix A — running consumer:** when a timestamped `/subscribe` arrives for an
already-running consumer, we now clear the watermark and re-seek to the
requested timestamp. The watermark is cleared first so that replayed historical
messages are not silently dropped by stale high-offset entries.

**Fix B — new consumer:** previously, starting a new topic consumer without an
explicit timestamp skipped the seek entirely and relied on the Kafka consumer
group's committed offsets (the old comment read "crash recovery relies on
committed offsets"). The consumer now always seeks to `timestamp ?? 1 minute ago`,
consistent with the single-instance behavior and ensuring recent messages are
captured even when committed offsets point to an older position.

## Tests

- Unit tests for simplified dedupe logic (offset compare + duplicate/insert paths)
- Redis integration tests for sequential dedupe and per-partition behavior (opt-in)
- Unit tests for `reseekToTimestamp` behavior and ordering
- Unit tests for `ensureTopicConsumerRunning` re-seek trigger conditions
