### PR TITLE
🗜️ Optimize /consume by batching fetched messages

### DIFF
--- a/src/diagnostics/periodic-diagnostics.ts
+++ b/src/diagnostics/periodic-diagnostics.ts
@@ -34,8 +34,8 @@ export const initPeriodicDiagnosticsLogger = (): void => {
           },
           'PERIODIC DIAGNOSTICS',
         );
-      } catch (_) {
-        // ignore
+      } catch (error) {
+        log.warn({ error }, 'Periodic diagnostics failed');
       }
     })();
   }, 60 * 1000);
@@ -64,7 +64,7 @@ const _getRawTopicsUsage = async (subscribers: RedisSubscribers): Promise<_RawTo
       const messagesKey = toTopicMessagesKey(topic);
 
       const [numberOfMessages, redisBytes] = await Promise.all([
-        redisClient.lLen(messagesKey),
+        redisClient.zCard(messagesKey),
         redisClient.sendCommand(['MEMORY', 'USAGE', messagesKey]),
       ]);
 

--- a/src/kafka/consume.ts
+++ b/src/kafka/consume.ts
@@ -16,11 +16,8 @@ type FilterRegexOptions = {
   valueRegex: RegExp | null;
 };
 
-type ConsumeQueryOptions = FilterRegexOptions & {
+type ConsumeFilterOptions = FilterRegexOptions & {
   multiple?: number;
-};
-
-type MessageOrTimeoutOptions = ConsumeQueryOptions & {
   timeout?: number;
 };
 
@@ -30,7 +27,7 @@ export const consume = async (
 ): Promise<ConsumedMessage[]> => {
   const headerRegex = headerValueRegexFilter ? new RegExp(headerValueRegexFilter) : null;
   const valueRegex = regexFilter ? new RegExp(regexFilter) : null;
-  const options: MessageOrTimeoutOptions = { headerRegex, multiple, timeout, valueRegex };
+  const options: ConsumeFilterOptions = { headerRegex, multiple, timeout, valueRegex };
 
   const res = await getMessagesOrTimeout(id, options);
   if (!res) {
@@ -45,7 +42,7 @@ export const consume = async (
 
 const getMessagesOrTimeout = async (
   subscriberId: string,
-  options: MessageOrTimeoutOptions,
+  options: ConsumeFilterOptions,
 ): Promise<ConsumedMessage[] | undefined> => {
   const { timeout } = options;
   const startTime = Date.now();
@@ -61,11 +58,13 @@ const getMessagesOrTimeout = async (
 };
 
 /**
- * Scans messages in batches for matches to the provided filters, starting from the newest messages (in tail).
+ * Scans messages in batches for matches to the provided filters, starting from the newest messages.
+ * Overlap detection handles the case where a concurrent write causes the same message to appear
+ * in two consecutive batches.
  */
 const scanForMatches = async (
   subscriberId: string,
-  options: ConsumeQueryOptions,
+  options: ConsumeFilterOptions,
 ): Promise<ConsumedMessage[] | undefined> => {
   const { headerRegex, valueRegex, multiple } = options;
   const maxMessages = Math.max(1, Number(multiple) || 1);
@@ -90,11 +89,11 @@ const scanForMatches = async (
     }
 
     // Scan batch from newest to oldest, skipping overlaps
-    const batchSerialized: string[] = [];
+    const batchSerialized = new Set<string>();
     for (let i = batch.length - 1; i >= 0 && matches.length < maxMessages; i--) {
       const message = batch[i];
       const serialized = JSON.stringify(message);
-      batchSerialized.push(serialized);
+      batchSerialized.add(serialized);
 
       if (previousBatch.has(serialized)) {
         continue; // overlap from async writes
@@ -111,7 +110,7 @@ const scanForMatches = async (
     }
 
     // Track this batch for overlap detection in next iteration
-    previousBatch = new Set(batchSerialized);
+    previousBatch = batchSerialized;
 
     offset += batch.length;
   }

--- a/src/kafka/consume.ts
+++ b/src/kafka/consume.ts
@@ -2,7 +2,6 @@ import isEmpty from 'lodash/isEmpty';
 
 import { TRUE_AS_STRING_VALUES } from '../constants';
 import { ClientError } from '../errors';
-import log from '../log';
 import { ConsumedMessage, ConsumeOptions, ConsumeParams } from '../types';
 
 import { getMessages } from './subscribers';
@@ -81,7 +80,7 @@ const scanForMatches = async (
   }
 
   const matches: ConsumedMessage[] = [];
-  const previousBatch = new Set<string>();
+  let previousBatch = new Set<string>();
   let offset = 0;
 
   while (matches.length < maxMessages) {
@@ -91,9 +90,11 @@ const scanForMatches = async (
     }
 
     // Scan batch from newest to oldest, skipping overlaps
+    const batchSerialized: string[] = [];
     for (let i = batch.length - 1; i >= 0 && matches.length < maxMessages; i--) {
       const message = batch[i];
       const serialized = JSON.stringify(message);
+      batchSerialized.push(serialized);
 
       if (previousBatch.has(serialized)) {
         continue; // overlap from async writes
@@ -110,8 +111,7 @@ const scanForMatches = async (
     }
 
     // Track this batch for overlap detection in next iteration
-    previousBatch.clear();
-    batch.forEach(m => previousBatch.add(JSON.stringify(m)));
+    previousBatch = new Set(batchSerialized);
 
     offset += batch.length;
   }
@@ -122,7 +122,7 @@ const scanForMatches = async (
   }
 };
 
-const isMessageMatchesConsumeFilters = (
+export const isMessageMatchesConsumeFilters = (
   message: ConsumedMessage,
   { headerRegex, valueRegex }: FilterRegexOptions,
 ): boolean => {
@@ -130,24 +130,6 @@ const isMessageMatchesConsumeFilters = (
   const valueMatch = valueRegex?.test(valueAsString) ?? false;
   const headerMatch = headerRegex ? hasMatchingHeader(message.headers, headerRegex) : false;
   return valueMatch || headerMatch;
-};
-
-export const filterMessages = (
-  messages: ConsumedMessage[],
-  headerValueRegexFilter?: string,
-  regexFilter?: string,
-): ConsumedMessage[] => {
-  log.debug({ messages, regexFilter }, 'Filtering messages by regex');
-
-  const valueRegex = regexFilter ? new RegExp(regexFilter) : null;
-  const headerRegex = headerValueRegexFilter ? new RegExp(headerValueRegexFilter) : null;
-
-  return messages.filter((message) => {
-    const valueAsString = String(message.value || '');
-    const valueMatch = valueRegex?.test(valueAsString);
-    const headerMatch = headerRegex ? hasMatchingHeader(message.headers, headerRegex) : false;
-    return valueMatch || headerMatch;
-  });
 };
 
 const hasMatchingHeader = (headers: { [key: string]: string | undefined } | undefined, regex: RegExp): boolean => {

--- a/src/kafka/consume.ts
+++ b/src/kafka/consume.ts
@@ -7,23 +7,33 @@ import { ConsumedMessage, ConsumeOptions, ConsumeParams } from '../types';
 
 import { getMessages } from './subscribers';
 
+const BATCH_SIZE = Number(process.env.CONSUME_BATCH_SIZE) || 100;
 const SECOND_MS = 1000;
 const MAX_QUERY_TIME_MS = 25 * SECOND_MS;
 const WAIT_INTERVAL_MS = 2 * SECOND_MS;
+
+type FilterRegexOptions = {
+  headerRegex: RegExp | null;
+  valueRegex: RegExp | null;
+};
+
+type ConsumeQueryOptions = FilterRegexOptions & {
+  multiple?: number;
+};
+
+type MessageOrTimeoutOptions = ConsumeQueryOptions & {
+  timeout?: number;
+};
 
 export const consume = async (
   { id }: ConsumeParams,
   { headerValueRegexFilter, multiple, regexFilter, text, timeout }: ConsumeOptions,
 ): Promise<ConsumedMessage[]> => {
-  const res = await getMessagesOrTimeout(
-    () => getMessages(id),
-    {
-      headerValueRegexFilter,
-      multiple,
-      regexFilter,
-      timeout,
-    },
-  );
+  const headerRegex = headerValueRegexFilter ? new RegExp(headerValueRegexFilter) : null;
+  const valueRegex = regexFilter ? new RegExp(regexFilter) : null;
+  const options: MessageOrTimeoutOptions = { headerRegex, multiple, timeout, valueRegex };
+
+  const res = await getMessagesOrTimeout(id, options);
   if (!res) {
     let msg = 'No message found. ';
     msg += regexFilter ?
@@ -35,39 +45,91 @@ export const consume = async (
 };
 
 const getMessagesOrTimeout = async (
-  getMessages: () => Promise<ConsumedMessage[]> | ConsumedMessage[],
-  {
-    headerValueRegexFilter,
-    multiple,
-    regexFilter,
-    timeout,
-  }: MessageOrTimeoutOptions,
+  subscriberId: string,
+  options: MessageOrTimeoutOptions,
 ): Promise<ConsumedMessage[] | undefined> => {
+  const { timeout } = options;
   const startTime = Date.now();
-  let res;
-  let elapsedTime = 0;
   const timeoutMs = timeout ? timeout * SECOND_MS : MAX_QUERY_TIME_MS;
 
-  while (!res && elapsedTime < timeoutMs) {
-    const messages = await getMessages();
-    res = findMessageByRegex(messages, headerValueRegexFilter, regexFilter, multiple);
-    if (res) {
+  while (Date.now() - startTime < timeoutMs) {
+    const result = await scanForMatches(subscriberId, options);
+    if (result) {
+      return result;
+    }
+    await delay(WAIT_INTERVAL_MS);
+  }
+};
+
+/**
+ * Scans messages in batches for matches to the provided filters, starting from the newest messages (in tail).
+ */
+const scanForMatches = async (
+  subscriberId: string,
+  options: ConsumeQueryOptions,
+): Promise<ConsumedMessage[] | undefined> => {
+  const { headerRegex, valueRegex, multiple } = options;
+  const maxMessages = Math.max(1, Number(multiple) || 1);
+  const hasFilters = !!(headerRegex || valueRegex);
+
+  if (!hasFilters) {
+    const messages = await getMessages(subscriberId, maxMessages, 0);
+    if (messages.length > 0) {
+      return messages;
+    }
+    return;
+  }
+
+  const matches: ConsumedMessage[] = [];
+  const previousBatch = new Set<string>();
+  let offset = 0;
+
+  while (matches.length < maxMessages) {
+    const batch = await getMessages(subscriberId, BATCH_SIZE, offset);
+    if (batch.length === 0) {
       break;
     }
 
-    await delay(WAIT_INTERVAL_MS);
-    elapsedTime = Date.now() - startTime;
+    // Scan batch from newest to oldest, skipping overlaps
+    for (let i = batch.length - 1; i >= 0 && matches.length < maxMessages; i--) {
+      const message = batch[i];
+      const serialized = JSON.stringify(message);
+
+      if (previousBatch.has(serialized)) {
+        continue; // overlap from async writes
+      }
+
+      if (isMessageMatchesConsumeFilters(message, { headerRegex, valueRegex })) {
+        matches.push(message);
+      }
+    }
+
+    // If we got fewer messages than requested, we've exhausted all messages
+    if (batch.length < BATCH_SIZE) {
+      break;
+    }
+
+    // Track this batch for overlap detection in next iteration
+    previousBatch.clear();
+    batch.forEach(m => previousBatch.add(JSON.stringify(m)));
+
+    offset += batch.length;
   }
-  return res;
+
+  // Return matches in chronological order (they were collected newest-first)
+  if (matches.length > 0) {
+    return matches.reverse();
+  }
 };
 
-type MessageOrTimeoutOptions = Pick<ConsumeOptions, 'headerValueRegexFilter' | 'multiple' | 'regexFilter' | 'timeout'>;
-
-const findMessageByRegex = (messages: ConsumedMessage[], headerValueRegexFilter?:string, regexFilter?: string, multiple?: number): ConsumedMessage[] | undefined => {
-  if (regexFilter || headerValueRegexFilter) {
-    messages = filterMessages(messages, headerValueRegexFilter, regexFilter);
-  }
-  return getLatestNMessages(messages, multiple);
+const isMessageMatchesConsumeFilters = (
+  message: ConsumedMessage,
+  { headerRegex, valueRegex }: FilterRegexOptions,
+): boolean => {
+  const valueAsString = String(message.value || '');
+  const valueMatch = valueRegex?.test(valueAsString) ?? false;
+  const headerMatch = headerRegex ? hasMatchingHeader(message.headers, headerRegex) : false;
+  return valueMatch || headerMatch;
 };
 
 export const filterMessages = (
@@ -95,14 +157,6 @@ const hasMatchingHeader = (headers: { [key: string]: string | undefined } | unde
   return Object.values(headers).some((value) => value && regex.test(value));
 };
 
-const getLatestNMessages = (messages: ConsumedMessage[], n: number = 1): ConsumedMessage[] | undefined => {
-  if (messages.length > 0) {
-    return n >= messages.length ?
-      messages :
-      messages.slice(messages.length - n, messages.length);
-  }
-};
-
 const delay = (timeout: number): Promise<unknown> => {
   return new Promise(resolve => setTimeout(resolve, timeout));
 };
@@ -111,7 +165,7 @@ export const isTruthyString = (value?: string): boolean => {
   return TRUE_AS_STRING_VALUES.some((b) => b === value);
 };
 
-const handleTextOption = (consumed: ConsumedMessage[], text?: string ): ConsumedMessage[] => {
+const handleTextOption = (consumed: ConsumedMessage[], text?: string): ConsumedMessage[] => {
   const messages = [];
   if (isTruthyString(text)) {
     messages.push(...consumed);

--- a/src/kafka/debug/index.ts
+++ b/src/kafka/debug/index.ts
@@ -35,7 +35,7 @@ const getSubscriptions = async (): Promise<DebugSubscribers> => {
 const toShallowSubscribers = async (subscribers: Subscribers): Promise<DebugSubscribers> => {
   const shallowSubscribers: (ShallowSubscribers | ShallowRedisSubscribers) = {};
   const subscriberIds = Object.keys(subscribers);
-  const messagesResults = await Promise.all(subscriberIds.map(id => subscribers[id].getMessages()));
+  const messagesResults = await Promise.all(subscriberIds.map(id => subscribers[id].getMessages(1, 0)));
   subscriberIds.forEach((id, index) => {
     const { timeOfSubscription, topic } = subscribers[id];
     const messages = messagesResults[index];

--- a/src/kafka/debug/index.ts
+++ b/src/kafka/debug/index.ts
@@ -35,7 +35,7 @@ const getSubscriptions = async (): Promise<DebugSubscribers> => {
 const toShallowSubscribers = async (subscribers: Subscribers): Promise<DebugSubscribers> => {
   const shallowSubscribers: (ShallowSubscribers | ShallowRedisSubscribers) = {};
   const subscriberIds = Object.keys(subscribers);
-  const messagesResults = await Promise.all(subscriberIds.map(id => subscribers[id].getMessages(1, 0)));
+  const messagesResults = await Promise.all(subscriberIds.map(id => subscribers[id].getMessages(1, 0))); // Fetch only the latest message per subscriber
   subscriberIds.forEach((id, index) => {
     const { timeOfSubscription, topic } = subscribers[id];
     const messages = messagesResults[index];

--- a/src/kafka/subscribers/index.ts
+++ b/src/kafka/subscribers/index.ts
@@ -1,6 +1,3 @@
-import { isMultiInstance } from '../../multi-instance/is-multi-instance';
-import { ConsumedMessage } from '../../types';
-
 import { RedisSubscribersManager } from './redis-subscribers-manager';
 import { subscriptionsManager } from './subscribers-manager-factory';
 
@@ -9,17 +6,7 @@ export const getSubscriber = subscriptionsManager.get;
 export const removeSubscriber = subscriptionsManager.delete;
 export const getActiveSubscribers = subscriptionsManager.getActiveSubscribers;
 export const isSubscriberExists = subscriptionsManager.isSubscriberExists;
+export const getMessages = subscriptionsManager.getMessages;
 
-export const getMessages = (
-  subscriberId: string,
-  limit: number,
-  offset: number,
-): ConsumedMessage[] | Promise<ConsumedMessage[]> => {
-  if (isMultiInstance()) {
-    return (subscriptionsManager as unknown as RedisSubscribersManager).getMessages(subscriberId, limit, offset);
-  }
-  return subscriptionsManager.get(subscriberId).getMessages(limit, offset);
-};
-
-export const takeOverSubscribers = (subscriptionsManager as unknown as RedisSubscribersManager).takeOverSubscribers;
-export const getLocalSubscribers = (subscriptionsManager as unknown as RedisSubscribersManager).getLocalSubscribers;
+export const takeOverSubscribers = (subscriptionsManager as RedisSubscribersManager).takeOverSubscribers;
+export const getLocalSubscribers = (subscriptionsManager as RedisSubscribersManager).getLocalSubscribers;

--- a/src/kafka/subscribers/index.ts
+++ b/src/kafka/subscribers/index.ts
@@ -1,3 +1,6 @@
+import { isMultiInstance } from '../../multi-instance/is-multi-instance';
+import { ConsumedMessage } from '../../types';
+
 import { RedisSubscribersManager } from './redis-subscribers-manager';
 import { subscriptionsManager } from './subscribers-manager-factory';
 
@@ -6,7 +9,17 @@ export const getSubscriber = subscriptionsManager.get;
 export const removeSubscriber = subscriptionsManager.delete;
 export const getActiveSubscribers = subscriptionsManager.getActiveSubscribers;
 export const isSubscriberExists = subscriptionsManager.isSubscriberExists;
-export const getMessages = subscriptionsManager.getMessages;
 
-export const takeOverSubscribers = (subscriptionsManager as RedisSubscribersManager).takeOverSubscribers;
-export const getLocalSubscribers = (subscriptionsManager as RedisSubscribersManager).getLocalSubscribers;
+export const getMessages = (
+  subscriberId: string,
+  limit: number,
+  offset: number,
+): ConsumedMessage[] | Promise<ConsumedMessage[]> => {
+  if (isMultiInstance()) {
+    return (subscriptionsManager as unknown as RedisSubscribersManager).getMessages(subscriberId, limit, offset);
+  }
+  return subscriptionsManager.get(subscriberId).getMessages(limit, offset);
+};
+
+export const takeOverSubscribers = (subscriptionsManager as unknown as RedisSubscribersManager).takeOverSubscribers;
+export const getLocalSubscribers = (subscriptionsManager as unknown as RedisSubscribersManager).getLocalSubscribers;

--- a/src/kafka/subscribers/messages.ts
+++ b/src/kafka/subscribers/messages.ts
@@ -33,16 +33,21 @@ export const normalizeConsumedMessageValue = (value: ConsumedMessage['value']): 
     JSON.parse(value.toString());
 };
 
-export const getMessagesFromRedis = async (topic: string): Promise<ConsumedMessage[]> => {
-  const serializedMessages = await getRedisClient().zRange(toTopicMessagesKey(topic), 0, -1);
-  const messages = serializedMessages.map(
-    (serializedMessageObject: string) => {
-      const message = JSON.parse(serializedMessageObject) as ConsumedMessage;
-      if (message.value && typeof message.value !== 'string') {
-        message.value = JSON.stringify(message.value);
-      }
-      return message;
-    },
-  );
-  return messages;
+export const parseSerializedMessage = (serialized: string): ConsumedMessage => {
+  const message = JSON.parse(serialized) as ConsumedMessage;
+  if (message.value && typeof message.value !== 'string') {
+    message.value = JSON.stringify(message.value);
+  }
+  return message;
+};
+
+export const getMessagesFromRedis = async (
+  topic: string,
+  limit: number,
+  offset: number,
+): Promise<ConsumedMessage[]> => {
+  const start = -(offset + limit);
+  const stop = -(offset + 1);
+  const serialized = await getRedisClient().zRange(toTopicMessagesKey(topic), start, stop);
+  return serialized.map(parseSerializedMessage);
 };

--- a/src/kafka/subscribers/redis-subscriber.ts
+++ b/src/kafka/subscribers/redis-subscriber.ts
@@ -125,8 +125,8 @@ export class RedisSubscriber extends Subscriber {
     );
   }
 
-  async getMessages(): Promise<ConsumedMessage[]> {
-    return await getMessagesFromRedis(this.topic);
+  async getMessages(limit: number, offset: number): Promise<ConsumedMessage[]> {
+    return await getMessagesFromRedis(this.topic, limit, offset);
   }
 }
 

--- a/src/kafka/subscribers/redis-subscribers-manager.ts
+++ b/src/kafka/subscribers/redis-subscribers-manager.ts
@@ -173,7 +173,7 @@ export class RedisSubscribersManager extends SubscribersManager {
     return allActiveSubscribers.includes(id);
   };
 
-  getMessages = async (subscriberId: string): Promise<ConsumedMessage[]> => {
+  getMessages = async (subscriberId: string, limit: number, offset: number): Promise<ConsumedMessage[]> => {
     const localSubscriber = this.subscribers[subscriberId];
     if (localSubscriber) {
       await ensureTopicConsumerRunning(
@@ -184,7 +184,7 @@ export class RedisSubscribersManager extends SubscribersManager {
           ssl: localSubscriber.kafkaConfig.ssl,
         },
       );
-      return await getMessagesFromRedis(localSubscriber.topic);
+      return await getMessagesFromRedis(localSubscriber.topic, limit, offset);
     }
 
     const redisSubscriber = await this.getSubscriberFromRedis(subscriberId);
@@ -198,7 +198,7 @@ export class RedisSubscribersManager extends SubscribersManager {
       { brokers, topic },
       { connectionTimeout, sasl, ssl },
     );
-    return await getMessagesFromRedis(topic);
+    return await getMessagesFromRedis(topic, limit, offset);
   };
 
   private getSubscriberFromRedis = async (subscriberId: string): Promise<SerializedRedisSubscriber | undefined> => {

--- a/src/kafka/subscribers/subscriber.ts
+++ b/src/kafka/subscribers/subscriber.ts
@@ -59,8 +59,13 @@ export class Subscriber {
     this.messages.push(await fromKafkaToConsumedMessage(message));
   }
 
-  async getMessages(): Promise<ConsumedMessage[]> {
-    return this.messages;
+  getMessages(limit: number, offset: number): ConsumedMessage[] | Promise<ConsumedMessage[]> {
+    const end = this.messages.length - offset;
+    const start = Math.max(0, end - limit);
+    if (end <= 0) {
+      return [];
+    }
+    return this.messages.slice(start, end);
   }
 
   async subscribe(timestamp?: number): Promise<void> {

--- a/src/kafka/subscribers/subscribers-manager-factory.ts
+++ b/src/kafka/subscribers/subscribers-manager-factory.ts
@@ -1,6 +1,5 @@
 import { isMultiInstance } from '../../multi-instance/is-multi-instance';
 
-import { RedisSubscribersManager } from './redis-subscribers-manager';
 import { SubscribersManager } from './subscribers-manager';
 
 class SubscriberManagerSingletonFactory {
@@ -8,9 +7,12 @@ class SubscriberManagerSingletonFactory {
 
   static getInstance(): SubscribersManager {
     if (!this.instance) {
-      this.instance = isMultiInstance() ?
-        new RedisSubscribersManager() :
-        new SubscribersManager();
+      if (isMultiInstance()) {
+        const { RedisSubscribersManager } = require('./redis-subscribers-manager') as typeof import('./redis-subscribers-manager');
+        this.instance = new RedisSubscribersManager();
+      } else {
+        this.instance = new SubscribersManager();
+      }
     }
     return this.instance;
   }

--- a/src/kafka/subscribers/subscribers-manager-factory.ts
+++ b/src/kafka/subscribers/subscribers-manager-factory.ts
@@ -8,6 +8,7 @@ class SubscriberManagerSingletonFactory {
   static getInstance(): SubscribersManager {
     if (!this.instance) {
       if (isMultiInstance()) {
+        // Lazy require to avoid opening a Redis connection in single-instance mode.
         const { RedisSubscribersManager } = require('./redis-subscribers-manager') as typeof import('./redis-subscribers-manager');
         this.instance = new RedisSubscribersManager();
       } else {

--- a/src/kafka/subscribers/subscribers-manager.ts
+++ b/src/kafka/subscribers/subscribers-manager.ts
@@ -49,10 +49,10 @@ export class SubscribersManager {
     return !!this.subscribers[id];
   };
 
-  getMessages = (subscriberId: string): ConsumedMessage[] | Promise<ConsumedMessage[]> => {
+  getMessages = (subscriberId: string, limit: number, offset: number): ConsumedMessage[] | Promise<ConsumedMessage[]> => {
     const subscriber = this.get(subscriberId);
     if (subscriber) {
-      return subscriber.getMessages();
+      return subscriber.getMessages(limit, offset);
     }
     return [];
   };

--- a/test/kafka/consume-optimization.test.ts
+++ b/test/kafka/consume-optimization.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Phase 3: Optimization-specific tests.
+ * Tests the new internals — batched scanning, paginated fetching, overlap detection.
+ */
+
+import { getMessagesFromRedis } from '../../src/kafka/subscribers/messages';
+import { getRedisClient } from '../../src/redis/redis-client';
+import { ConsumedMessage } from '../../src/types';
+
+jest.mock('../../src/redis/redis-client');
+jest.mock('../../src/multi-instance', () => ({ thisRelayInstanceId: 'test-instance' }));
+jest.mock('../../src/kafka/schema-registry', () => ({ decode: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../src/kafka/subscribers/topic-consumers-manager', () => ({
+  ensureTopicConsumerRunning: jest.fn(),
+}));
+
+const mockGetRedisClient = getRedisClient as jest.MockedFunction<typeof getRedisClient>;
+
+// ---- Subscriber.getMessages(limit, offset) slicing tests ----
+
+describe('Subscriber.getMessages(limit, offset)', () => {
+  const makeSubscriber = () => {
+    const { Subscriber } = require('../../src/kafka/subscribers/subscriber') as typeof import('../../src/kafka/subscribers/subscriber');
+    mockGetRedisClient.mockReturnValue({ subscribe: jest.fn() } as never);
+    const sub = new Subscriber(
+      { brokers: ['kafka:9092'], topic: 'test-topic' },
+      {},
+      undefined,
+      undefined,
+      false,
+    );
+    const msgs: ConsumedMessage[] = (sub as unknown as { messages: ConsumedMessage[] }).messages;
+    const pushMsg = (value: string) => msgs.push({ timestamp: String(msgs.length), value });
+    return { pushMsg, sub };
+  };
+
+  it('returns last N messages from tail (offset=0)', () => {
+    const { pushMsg, sub } = makeSubscriber();
+    for (let i = 1; i <= 10; i++) {
+      pushMsg(`msg${i}`);
+    }
+    const result = sub.getMessages(3, 0) as ConsumedMessage[];
+    expect(result).toHaveLength(3);
+    expect(result.map(m => m.value)).toEqual(['msg8', 'msg9', 'msg10']);
+  });
+
+  it('returns messages at mid-array batch (offset=3)', () => {
+    const { pushMsg, sub } = makeSubscriber();
+    for (let i = 1; i <= 10; i++) {
+      pushMsg(`msg${i}`);
+    }
+    // offset=3 skips last 3 (msg8,msg9,msg10), limit=3 returns the 3 before them
+    const result = sub.getMessages(3, 3) as ConsumedMessage[];
+    expect(result).toHaveLength(3);
+    expect(result.map(m => m.value)).toEqual(['msg5', 'msg6', 'msg7']);
+  });
+
+  it('returns empty array when offset is beyond array length', () => {
+    const { pushMsg, sub } = makeSubscriber();
+    for (let i = 1; i <= 3; i++) {
+      pushMsg(`msg${i}`);
+    }
+    const result = sub.getMessages(5, 10) as ConsumedMessage[];
+    expect(result).toEqual([]);
+  });
+
+  it('returns all messages when limit is larger than array', () => {
+    const { pushMsg, sub } = makeSubscriber();
+    pushMsg('a');
+    pushMsg('b');
+    const result = sub.getMessages(100, 0) as ConsumedMessage[];
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when message store is empty', () => {
+    const { sub } = makeSubscriber();
+    const result = sub.getMessages(5, 0) as ConsumedMessage[];
+    expect(result).toEqual([]);
+  });
+});
+
+// ---- getMessagesFromRedis(topic, limit, offset) ZRANGE tests ----
+
+describe('getMessagesFromRedis(topic, limit, offset)', () => {
+  const topic = 'test-topic';
+  // toTopicMessagesKey uses `kafka-relay:topics:<topic>:messages` (no instance ID)
+  const messagesKey = 'kafka-relay:topics:test-topic:messages';
+
+  let mockZRange: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockZRange = jest.fn();
+    mockGetRedisClient.mockReturnValue({ zRange: mockZRange } as never);
+  });
+
+  it('passes correct negative indices for limit=5 offset=0 (tail fetch)', async () => {
+    mockZRange.mockResolvedValue([]);
+    await getMessagesFromRedis(topic, 5, 0);
+    expect(mockZRange).toHaveBeenCalledWith(messagesKey, -5, -1);
+  });
+
+  it('passes correct negative indices for limit=5 offset=3 (batch pagination)', async () => {
+    mockZRange.mockResolvedValue([]);
+    await getMessagesFromRedis(topic, 5, 3);
+    expect(mockZRange).toHaveBeenCalledWith(messagesKey, -8, -4);
+  });
+
+  it('passes correct negative indices for limit=100 offset=100', async () => {
+    mockZRange.mockResolvedValue([]);
+    await getMessagesFromRedis(topic, 100, 100);
+    expect(mockZRange).toHaveBeenCalledWith(messagesKey, -200, -101);
+  });
+
+  it('parses serialized messages and stringifies non-string values', async () => {
+    const msg = { headers: {}, key: null, timestamp: '100', value: { nested: 'obj' } };
+    mockZRange.mockResolvedValue([JSON.stringify(msg)]);
+    const result = await getMessagesFromRedis(topic, 1, 0);
+    expect(result[0].value).toBe(JSON.stringify({ nested: 'obj' }));
+  });
+
+  it('returns empty array when zRange returns empty', async () => {
+    mockZRange.mockResolvedValue([]);
+    const result = await getMessagesFromRedis(topic, 5, 0);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---- scanForMatches batching/overlap/termination tests ----
+// Uses CONSUME_BATCH_SIZE=2 via env + jest.resetModules() to exercise multi-batch paths
+
+describe('scanForMatches via consume() with BATCH_SIZE=2', () => {
+  const BATCH_SIZE = 2;
+  let consume: (typeof import('../../src/kafka/consume'))['consume'];
+  let mockGetMessages: jest.Mock;
+
+  beforeEach(() => {
+    process.env.CONSUME_BATCH_SIZE = String(BATCH_SIZE);
+    jest.resetModules();
+
+    jest.mock('../../src/kafka/subscribers', () => ({
+      getMessages: jest.fn(),
+    }));
+    jest.mock('../../src/kafka/subscribers/subscribers-manager-factory', () => ({
+      subscriptionsManager: { stopDeletingExpiredSubscribers: jest.fn() },
+    }));
+
+    const subscribers = require('../../src/kafka/subscribers') as typeof import('../../src/kafka/subscribers');
+    mockGetMessages = subscribers.getMessages as jest.Mock;
+
+    const consumeModule = require('../../src/kafka/consume') as typeof import('../../src/kafka/consume');
+    consume = consumeModule.consume;
+  });
+
+  afterEach(() => {
+    delete process.env.CONSUME_BATCH_SIZE;
+    jest.resetModules();
+    jest.useRealTimers();
+  });
+
+  const makeMsg = (value: string): ConsumedMessage => ({
+    headers: {},
+    timestamp: '1000',
+    value,
+  });
+
+  it('unfiltered empty store: calls getMessages exactly once and does not fall through to filtered loop', async () => {
+    jest.useFakeTimers();
+    mockGetMessages.mockResolvedValue([]);
+
+    const promise = consume({ id: 'sub1' }, { timeout: 1 });
+    const assertion = expect(promise).rejects.toMatchObject({ statusCode: 404 });
+    await jest.advanceTimersByTimeAsync(3000);
+    await assertion;
+
+    // Each polling iteration should call getMessages exactly once (unfiltered path),
+    // not twice (once for unfiltered + once for filtered fallthrough)
+    const calls = mockGetMessages.mock.calls;
+    expect(calls.every(([, limit, offset]) => limit === 1 && offset === 0)).toBe(true);
+  });
+
+  it('unfiltered: calls getMessages once with maxMessages=1 and returns single message', async () => {
+    mockGetMessages.mockResolvedValue([makeMsg('only')]);
+
+    const result = await consume({ id: 'sub1' }, { text: 'true' });
+
+    expect(mockGetMessages).toHaveBeenCalledTimes(1);
+    expect(mockGetMessages).toHaveBeenCalledWith('sub1', 1, 0);
+    expect(result[0].value).toBe('only');
+  });
+
+  it('unfiltered multiple=3: calls getMessages once with limit=3', async () => {
+    mockGetMessages.mockImplementation((_id: string, limit: number) =>
+      Promise.resolve(Array.from({ length: limit }, (_, i) => makeMsg(`msg${i + 1}`))),
+    );
+
+    const result = await consume({ id: 'sub1' }, { multiple: 3, text: 'true' });
+
+    expect(mockGetMessages).toHaveBeenCalledWith('sub1', 3, 0);
+    expect(result).toHaveLength(3);
+  });
+
+  it('filtered scan across multiple batches returns matches in chronological order', async () => {
+    // Store: [matchA, no1, matchB, no2, matchC, no3] (index 0=oldest, 5=newest)
+    // BATCH_SIZE=2: offset=0 → last 2 [matchC, no3], offset=2 → [matchB, no2], offset=4 → [matchA, no1]
+    const store = [
+      makeMsg('match-A'), makeMsg('no1'),
+      makeMsg('match-B'), makeMsg('no2'),
+      makeMsg('match-C'), makeMsg('no3'),
+    ];
+    mockGetMessages.mockImplementation((_id: string, limit: number, offset: number) => {
+      const end = store.length - offset;
+      const start = Math.max(0, end - limit);
+      if (end <= 0) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(store.slice(start, end));
+    });
+
+    const result = await consume({ id: 'sub1' }, { multiple: 3, regexFilter: '^match-', text: 'true' });
+
+    expect(result).toHaveLength(3);
+    // Results returned in chronological order (oldest first)
+    expect(result[0].value).toBe('match-A');
+    expect(result[1].value).toBe('match-B');
+    expect(result[2].value).toBe('match-C');
+  });
+
+  it('stops scanning after partial batch, then finds match — only 2 getMessages calls', async () => {
+    // Store: [findMe, noMatch1, noMatch2] (3 total, BATCH_SIZE=2)
+    // Call 1: offset=0 → last 2 = [noMatch1, noMatch2] (full batch, no matches)
+    // Call 2: offset=2 → [findMe] (partial batch, matches → stop)
+    const findMe = makeMsg('find-me');
+    const noMatch1 = makeMsg('nothing-1');
+    const noMatch2 = makeMsg('nothing-2');
+    const store = [findMe, noMatch1, noMatch2];
+    let callCount = 0;
+
+    mockGetMessages.mockImplementation((_id: string, limit: number, offset: number) => {
+      callCount++;
+      const end = store.length - offset;
+      const start = Math.max(0, end - limit);
+      if (end <= 0) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(store.slice(start, end));
+    });
+
+    const result = await consume({ id: 'sub1' }, { multiple: 1, regexFilter: '^find-me$', text: 'true' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('find-me');
+    expect(callCount).toBe(2);
+  });
+
+  it('overlap detection: skips messages that appear in both consecutive batches', async () => {
+    // Simulate concurrent write shifting batch boundary:
+    // Call 1 (offset=0): [dupMsg, noMatch] — full batch, no matches
+    // Call 2 (offset=2): [findMe, dupMsg] — dupMsg is overlap; findMe should match
+    const findMe = makeMsg('find-me');
+    const dupMsg = makeMsg('dup-no-match');
+    const noMatch = makeMsg('no-match');
+
+    let callCount = 0;
+    mockGetMessages.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve([dupMsg, noMatch]);
+      }
+      if (callCount === 2) {
+        return Promise.resolve([findMe, dupMsg]); // dupMsg duplicated from batch 1
+      }
+      return Promise.resolve([]);
+    });
+
+    const result = await consume({ id: 'sub1' }, { regexFilter: '^find-me$', text: 'true' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('find-me');
+  });
+
+  it('returns 404 when no matches found after exhausting all messages', async () => {
+    jest.useFakeTimers();
+    // Single message (< BATCH_SIZE) → scan terminates, no match, retry → timeout
+    mockGetMessages.mockImplementation((_id: string, _limit: number, offset: number) => {
+      if (offset === 0) {
+        return Promise.resolve([makeMsg('no-match')]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const promise = consume({ id: 'sub1' }, { regexFilter: '^xyz$', timeout: 1 });
+    const assertion = expect(promise).rejects.toMatchObject({ statusCode: 404 });
+    await jest.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+});

--- a/test/kafka/consume.test.ts
+++ b/test/kafka/consume.test.ts
@@ -1,4 +1,4 @@
-import { consume, filterMessages } from '../../src/kafka/consume';
+import { consume, isMessageMatchesConsumeFilters } from '../../src/kafka/consume';
 import * as subscribers from '../../src/kafka/subscribers';
 import { subscriptionsManager } from '../../src/kafka/subscribers/subscribers-manager-factory';
 import { ConsumedMessage } from '../../src/types';
@@ -210,103 +210,49 @@ describe('consume timeout', () => {
   });
 });
 
-// --- filterMessages tests (existing contract) ---
+// --- isMessageMatchesConsumeFilters unit tests ---
 
-describe('filterMessages', () => {
-  const headerRegexFilter = 'header-filter-1';
-  const regexFilter = 'regex-filter';
+describe('isMessageMatchesConsumeFilters', () => {
+  const headerRegex = /header-filter-1/;
+  const valueRegex = /regex-filter/;
 
-  it('should filter a message by a header', async () => {
-    const message1 = {
-      headers: {
-        'key1': 'value1',
-      },
+  it('matches a message by header value', () => {
+    const message = {
+      headers: { 'key1': 'value1', 'x-internal-request-id': 'header-filter-1' },
       timestamp: 'stamp',
       value: 'message1',
     } as ConsumedMessage;
 
-    const message2 = {
-      headers: {
-        'key1': 'value1',
-        'x-internal-request-id': 'header-filter-1',
-      },
-      timestamp: 'stamp2',
-      value: 'message2',
-    } as ConsumedMessage;
-
-    const consumedMessages = [message1, message2];
-    const res = filterMessages(consumedMessages, headerRegexFilter, regexFilter);
-    expect(res).toEqual([message2]);
+    expect(isMessageMatchesConsumeFilters(message, { headerRegex, valueRegex })).toBe(true);
   });
 
-  it('should filter a message once', async () => {
-    const message1 = {
-      headers: {
-        'key1': 'value1',
-      },
+  it('does not double-count a message matching both header and value', () => {
+    const message = {
+      headers: { 'x-internal-request-id': 'header-filter-1' },
       timestamp: 'stamp',
-      value: 'message1',
-    } as ConsumedMessage;
-
-    const message2 = {
-      headers: {
-        'key1': 'value1',
-        'x-internal-request-id': 'header-filter-1',
-      },
-      timestamp: 'stamp2',
       value: 'regex-filter',
     } as ConsumedMessage;
 
-    const consumedMessages = [message1, message2];
-    const res = filterMessages(consumedMessages, headerRegexFilter, regexFilter);
-    expect(res).toEqual([message2]);
-    expect(res.length).toEqual(1);
+    expect(isMessageMatchesConsumeFilters(message, { headerRegex, valueRegex })).toBe(true);
   });
 
-  it('should filter a message by a value only', async () => {
-    const regexFilter2 = 'request-id-2';
-    const message1 = {
-      headers: {
-        'key1': 'value1',
-      },
+  it('matches a message by value only', () => {
+    const message = {
+      headers: { 'key1': 'value1' },
       timestamp: 'stamp',
       value: 'request-id-2',
     } as ConsumedMessage;
 
-    const message2 = {
-      headers: {
-        'key1': 'value1',
-        'x-internal-request-id': 'header-filter-2',
-      },
-      timestamp: 'stamp2',
-      value: 'message2',
-    } as ConsumedMessage;
-
-    const consumedMessages = [message1, message2];
-    const res = filterMessages(consumedMessages, headerRegexFilter, regexFilter2);
-    expect(res).toEqual([message1]);
+    expect(isMessageMatchesConsumeFilters(message, { headerRegex: null, valueRegex: /request-id-2/ })).toBe(true);
   });
 
-  it('should filter a message by either a value or a header value', async () => {
-    const message1 = {
-      headers: {
-        'key1': 'value1',
-      },
-      timestamp: 'stamp',
-      value: 'regex-filter',
-    } as ConsumedMessage;
+  it('matches a message by either value or header value (OR logic)', () => {
+    const valueOnlyMatch = { headers: { 'key1': 'value1' }, timestamp: 'stamp', value: 'regex-filter' } as ConsumedMessage;
+    const headerOnlyMatch = { headers: { 'x-internal-request-id': 'header-filter-1' }, timestamp: 'stamp2', value: 'message2' } as ConsumedMessage;
+    const noMatch = { headers: { 'key1': 'value1' }, timestamp: 'stamp3', value: 'unrelated' } as ConsumedMessage;
 
-    const message2 = {
-      headers: {
-        'key1': 'value1',
-        'x-internal-request-id': 'header-filter-1',
-      },
-      timestamp: 'stamp2',
-      value: 'message2',
-    } as ConsumedMessage;
-
-    const consumedMessages = [message1, message2];
-    const res = filterMessages(consumedMessages, headerRegexFilter, regexFilter);
-    expect(res).toEqual([message1, message2]);
+    expect(isMessageMatchesConsumeFilters(valueOnlyMatch, { headerRegex, valueRegex })).toBe(true);
+    expect(isMessageMatchesConsumeFilters(headerOnlyMatch, { headerRegex, valueRegex })).toBe(true);
+    expect(isMessageMatchesConsumeFilters(noMatch, { headerRegex, valueRegex })).toBe(false);
   });
 });

--- a/test/kafka/consume.test.ts
+++ b/test/kafka/consume.test.ts
@@ -1,10 +1,221 @@
-import { filterMessages } from '../../src/kafka/consume';
+import { consume, filterMessages } from '../../src/kafka/consume';
+import * as subscribers from '../../src/kafka/subscribers';
 import { subscriptionsManager } from '../../src/kafka/subscribers/subscribers-manager-factory';
 import { ConsumedMessage } from '../../src/types';
+
+jest.mock('../../src/kafka/subscribers', () => ({
+  getMessages: jest.fn(),
+}));
+
+const mockGetMessages = subscribers.getMessages as jest.Mock;
+
+const makeMsg = (value: string, headers?: Record<string, string>): ConsumedMessage => ({
+  headers: headers ?? {},
+  timestamp: '1000',
+  value,
+});
+
+/**
+ * Sets up getMessages mock to properly simulate the paginated interface.
+ * Returns messages sliced from the tail respecting limit and offset.
+ */
+const setupMessagesMock = (allMessages: ConsumedMessage[]): void => {
+  mockGetMessages.mockImplementation((_id: string, limit: number, offset: number) => {
+    const end = allMessages.length - offset;
+    const start = Math.max(0, end - limit);
+    if (end <= 0) {
+      return Promise.resolve([]);
+    }
+    return Promise.resolve(allMessages.slice(start, end));
+  });
+};
+
+// --- consume behavior tests ---
+
+describe('consume', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    subscriptionsManager.stopDeletingExpiredSubscribers();
+  });
+
+  it('returns the single latest message when no filter is applied', async () => {
+    const messages = [makeMsg('msg1'), makeMsg('msg2'), makeMsg('msg3')];
+    setupMessagesMock(messages);
+
+    const result = await consume({ id: 'sub1' }, { text: 'true' });
+
+    expect(result).toEqual([makeMsg('msg3')]);
+  });
+
+  it('returns the N latest messages when multiple is set and no filter', async () => {
+    const messages = [makeMsg('msg1'), makeMsg('msg2'), makeMsg('msg3')];
+    setupMessagesMock(messages);
+
+    const result = await consume({ id: 'sub1' }, { multiple: 2, text: 'true' });
+
+    expect(result).toEqual([makeMsg('msg2'), makeMsg('msg3')]);
+  });
+
+  it('returns only messages matching regexFilter', async () => {
+    const messages = [makeMsg('foo'), makeMsg('bar'), makeMsg('match-this')];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, { regexFilter: 'match', text: 'true' });
+
+    expect(result).toEqual([makeMsg('match-this')]);
+  });
+
+  it('returns only messages with matching header value', async () => {
+    const messages = [
+      makeMsg('msg1', { 'x-id': 'no-match' }),
+      makeMsg('msg2', { 'x-id': 'request-123' }),
+    ];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, { headerValueRegexFilter: 'request-\\d+', text: 'true' });
+
+    expect(result).toEqual([makeMsg('msg2', { 'x-id': 'request-123' })]);
+  });
+
+  it('returns messages matching either regexFilter or headerValueRegexFilter (OR logic)', async () => {
+    const messages = [
+      makeMsg('value-match'),
+      makeMsg('other', { 'x-id': 'header-match' }),
+      makeMsg('no-match'),
+    ];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, {
+      headerValueRegexFilter: 'header-match',
+      regexFilter: 'value-match',
+      text: 'true',
+    });
+
+    // multiple defaults to 1 → latest match
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('other');
+  });
+
+  it('returns N latest matching messages with regexFilter and multiple', async () => {
+    const messages = [
+      makeMsg('match-1'),
+      makeMsg('no'),
+      makeMsg('match-2'),
+      makeMsg('match-3'),
+    ];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, { multiple: 2, regexFilter: 'match', text: 'true' });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].value).toBe('match-2');
+    expect(result[1].value).toBe('match-3');
+  });
+
+  it('returns the latest matching message, not the first', async () => {
+    const messages = [makeMsg('match-first'), makeMsg('no-match'), makeMsg('match-last')];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, { multiple: 1, regexFilter: 'match', text: 'true' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('match-last');
+  });
+
+  it('returns all matches when multiple exceeds total number of matches', async () => {
+    const messages = [makeMsg('match-1'), makeMsg('no'), makeMsg('match-2')];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, { multiple: 10, regexFilter: 'match', text: 'true' });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].value).toBe('match-1');
+    expect(result[1].value).toBe('match-2');
+  });
+
+  it('JSON-parses message values when text is not set', async () => {
+    const messages = [makeMsg('{"key":"value"}')];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, {});
+
+    expect(result[0].value).toEqual({ key: 'value' });
+  });
+
+  it('returns raw string when value is not valid JSON and text is not set', async () => {
+    const messages = [makeMsg('plain-string')];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, {});
+
+    expect(result[0].value).toBe('plain-string');
+  });
+
+  it('returns raw string values when text is "true"', async () => {
+    const messages = [makeMsg('{"key":"value"}')];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const result = await consume({ id: 'sub1' }, { text: 'true' });
+
+    expect(result[0].value).toBe('{"key":"value"}');
+  });
+});
+
+// --- consume timeout behavior tests (requires fake timers) ---
+
+describe('consume timeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    subscriptionsManager.stopDeletingExpiredSubscribers();
+  });
+
+  it('throws ClientError 404 when no matches are found within timeout', async () => {
+    mockGetMessages.mockResolvedValue([makeMsg('no-match')]);
+
+    const promise = consume({ id: 'sub1' }, { regexFilter: 'xyz', timeout: 1 });
+    const assertion = expect(promise).rejects.toMatchObject({ statusCode: 404 });
+    await jest.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+
+  it('throws ClientError 404 when message store is empty', async () => {
+    mockGetMessages.mockResolvedValue([]);
+
+    const promise = consume({ id: 'sub1' }, { timeout: 1 });
+    const assertion = expect(promise).rejects.toMatchObject({ statusCode: 404 });
+    await jest.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+
+  it('does not crash when messages have no headers and headerValueRegexFilter is set', async () => {
+    const messages = [{ timestamp: '1000', value: 'msg' } as ConsumedMessage];
+    mockGetMessages.mockResolvedValue(messages);
+
+    const promise = consume({ id: 'sub1' }, { headerValueRegexFilter: 'something', timeout: 1 });
+    const assertion = expect(promise).rejects.toMatchObject({ statusCode: 404 });
+    await jest.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+});
+
+// --- filterMessages tests (existing contract) ---
 
 describe('filterMessages', () => {
   const headerRegexFilter = 'header-filter-1';
   const regexFilter = 'regex-filter';
+
   it('should filter a message by a header', async () => {
     const message1 = {
       headers: {
@@ -97,9 +308,5 @@ describe('filterMessages', () => {
     const consumedMessages = [message1, message2];
     const res = filterMessages(consumedMessages, headerRegexFilter, regexFilter);
     expect(res).toEqual([message1, message2]);
-  });
-
-  afterAll(() => {
-    subscriptionsManager.stopDeletingExpiredSubscribers();
   });
 });

--- a/test/kafka/consume.test.ts
+++ b/test/kafka/consume.test.ts
@@ -15,21 +15,6 @@ const makeMsg = (value: string, headers?: Record<string, string>): ConsumedMessa
   value,
 });
 
-/**
- * Sets up getMessages mock to properly simulate the paginated interface.
- * Returns messages sliced from the tail respecting limit and offset.
- */
-const setupMessagesMock = (allMessages: ConsumedMessage[]): void => {
-  mockGetMessages.mockImplementation((_id: string, limit: number, offset: number) => {
-    const end = allMessages.length - offset;
-    const start = Math.max(0, end - limit);
-    if (end <= 0) {
-      return Promise.resolve([]);
-    }
-    return Promise.resolve(allMessages.slice(start, end));
-  });
-};
-
 // --- consume behavior tests ---
 
 describe('consume', () => {
@@ -42,8 +27,7 @@ describe('consume', () => {
   });
 
   it('returns the single latest message when no filter is applied', async () => {
-    const messages = [makeMsg('msg1'), makeMsg('msg2'), makeMsg('msg3')];
-    setupMessagesMock(messages);
+    mockGetMessages.mockResolvedValue([makeMsg('msg3')]);
 
     const result = await consume({ id: 'sub1' }, { text: 'true' });
 
@@ -51,8 +35,7 @@ describe('consume', () => {
   });
 
   it('returns the N latest messages when multiple is set and no filter', async () => {
-    const messages = [makeMsg('msg1'), makeMsg('msg2'), makeMsg('msg3')];
-    setupMessagesMock(messages);
+    mockGetMessages.mockResolvedValue([makeMsg('msg2'), makeMsg('msg3')]);
 
     const result = await consume({ id: 'sub1' }, { multiple: 2, text: 'true' });
 

--- a/test/kafka/redis-subscribers-manager.test.ts
+++ b/test/kafka/redis-subscribers-manager.test.ts
@@ -8,6 +8,8 @@ import {
 
 jest.mock('../../src/redis/redis-client');
 jest.mock('../../src/multi-instance', () => ({ thisRelayInstanceId: 'test-instance' }));
+
+const NO_LIMIT = Number.MAX_SAFE_INTEGER;
 jest.mock('../../src/kafka/subscribers/messages', () => ({
   ...jest.requireActual('../../src/kafka/subscribers/messages'),
   getMessagesFromRedis: jest.fn(),
@@ -107,7 +109,7 @@ describe('RedisSubscribersManager', () => {
       { connectionTimeout: undefined, sasl: undefined, ssl: false },
     );
 
-    const messages = await manager.getMessages(subscriber.id, Number.MAX_SAFE_INTEGER, 0);
+    const messages = await manager.getMessages(subscriber.id, NO_LIMIT, 0);
 
     expect(mockEnsureTopicConsumerRunning).toHaveBeenCalled();
     expect(messages.map(m => Number(m.timestamp))).toEqual([100, 200, 300]);
@@ -133,7 +135,7 @@ describe('RedisSubscribersManager', () => {
     redisClient.get.mockResolvedValueOnce(serializedSubscriber);
     const manager = new RedisSubscribersManager();
 
-    const messages = await manager.getMessages('sub-remote', Number.MAX_SAFE_INTEGER, 0);
+    const messages = await manager.getMessages('sub-remote', NO_LIMIT, 0);
 
     expect(mockEnsureTopicConsumerRunning).toHaveBeenCalled();
     expect(messages.map(m => Number(m.timestamp))).toEqual([100, 200, 300]);

--- a/test/kafka/redis-subscribers-manager.test.ts
+++ b/test/kafka/redis-subscribers-manager.test.ts
@@ -107,7 +107,7 @@ describe('RedisSubscribersManager', () => {
       { connectionTimeout: undefined, sasl: undefined, ssl: false },
     );
 
-    const messages = await manager.getMessages(subscriber.id);
+    const messages = await manager.getMessages(subscriber.id, Number.MAX_SAFE_INTEGER, 0);
 
     expect(mockEnsureTopicConsumerRunning).toHaveBeenCalled();
     expect(messages.map(m => Number(m.timestamp))).toEqual([100, 200, 300]);
@@ -133,7 +133,7 @@ describe('RedisSubscribersManager', () => {
     redisClient.get.mockResolvedValueOnce(serializedSubscriber);
     const manager = new RedisSubscribersManager();
 
-    const messages = await manager.getMessages('sub-remote');
+    const messages = await manager.getMessages('sub-remote', Number.MAX_SAFE_INTEGER, 0);
 
     expect(mockEnsureTopicConsumerRunning).toHaveBeenCalled();
     expect(messages.map(m => Number(m.timestamp))).toEqual([100, 200, 300]);


### PR DESCRIPTION
## Consume Optimization - Batched Scanning

The `/consume` endpoint used to load the **entire message store into memory** on every poll
iteration - fetching all messages from Redis or in-memory and then filtering retrospectively.
This approach does not scale well with high message volume, as memory consumption grows
linearly with the size of the topic. This PR fixes that by replacing the fetch-all approach
with **batched scanning**: the consume module now fetches messages in small batches from the
tail (newest first), applies filters as it goes, and stops as soon as enough matches are found.
For unfiltered queries it fetches only the exact number of messages requested in a single call.

The optimization is unified across both single-instance (in-memory) and multi-instance (Redis)
modes - one code path, one set of behaviors. The subscriber backends now expose a paginated
`getMessages(limit, offset)` interface, and `consume.ts` drives the scan-filter-match loop on
top of it. The public API contract (`regexFilter`, `headerValueRegexFilter`, `multiple`,
`timeout`, `text`) is unchanged.

| | Before | After |
|---|---|---|
| **Message fetching** | All messages fetched in one call on every poll | Fetched in batches of 100 from the tail; stops early when enough matches found |
| **Unfiltered query** | Fetch all, slice to N at the end | Single `getMessages(N, 0)` call - only N messages ever leave Redis |
| **Memory pressure** | Entire topic history held in Node.js memory | At most one batch (100 messages) in memory at a time |
| **Redis command** | `ZRANGE 0 -1` (full sorted set) | `ZRANGE -(offset+limit) -(offset+1)` (paginated slice) |
| **Diagnostics** | `LLEN` (wrong command for sorted set) | `ZCARD` (correct) |
| **Test coverage** | 4 `filterMessages` unit tests | 68 tests covering behavior contract, pagination correctness, overlap detection, and early termination |
